### PR TITLE
feat: caption refactor

### DIFF
--- a/src/hls-adapter.js
+++ b/src/hls-adapter.js
@@ -301,7 +301,7 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
   selectTextTrack(textTrack: TextTrack): void {
     if (textTrack instanceof TextTrack && !textTrack.active && this._videoElement.textTracks) {
       this._disableAllTextTracks();
-      this._videoElement.textTracks[textTrack.index].mode = 'showing';
+      this._videoElement.textTracks[textTrack.index].mode = 'hidden';
       HlsAdapter._logger.debug('Text track changed', textTrack);
       this._onTrackChanged(textTrack);
     }
@@ -440,7 +440,7 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
   _disableAllTextTracks() {
     let vidTextTracks = this._videoElement.textTracks;
     for (let i = 0; i < vidTextTracks.length; i++) {
-      vidTextTracks[i].mode = 'hidden';
+      vidTextTracks[i].mode = 'disabled';
     }
   }
 

--- a/test/src/hls-adapter.spec.js
+++ b/test/src/hls-adapter.spec.js
@@ -290,6 +290,7 @@ describe('HlsAdapter Instance - Unit', function () {
 
 describe('HlsAdapter Instance - Integration', function () {
 
+  let playerContainer;
   let player;
   let tracks;
   let videoTracks;
@@ -297,17 +298,18 @@ describe('HlsAdapter Instance - Integration', function () {
   let textTracks;
 
   before(function () {
-    TestUtils.createElement('DIV', targetId);
+    playerContainer = TestUtils.createElement('DIV', targetId);
   });
 
   beforeEach(function () {
-    player = loadPlayer(targetId, {
+    player = loadPlayer({
       sources: {
         hls: [
           hls_sources.ElephantsDream
         ]
       }
     });
+    playerContainer.appendChild(player.getView());
   });
 
   afterEach(function () {
@@ -375,10 +377,10 @@ describe('HlsAdapter Instance - Integration', function () {
         audioTracks = player.getTracks(player.Track.AUDIO);
         textTracks = player.getTracks(player.Track.TEXT);
         player.src.should.equal(hls_sources.ElephantsDream.url);
-        tracks.length.should.equal(14);
+        tracks.length.should.equal(15);
         videoTracks.length.should.equal(4);
         audioTracks.length.should.equal(3);
-        textTracks.length.should.equal(7);
+        textTracks.length.should.equal(8);
         player.addEventListener(player.Event.VIDEO_TRACK_CHANGED, onVideoTrackChanged.bind(null, done));
         player.selectTrack(videoTracks[2]);
       } else {

--- a/test/src/hls-adapter.spec.js
+++ b/test/src/hls-adapter.spec.js
@@ -205,7 +205,7 @@ describe('HlsAdapter Instance - Unit', function () {
     };
     hlsAdapterInstance._disableAllTextTracks();
     for (let i = 0; i < hlsAdapterInstance._videoElement.textTracks.length; i++) {
-      hlsAdapterInstance._videoElement.textTracks[i].mode.should.equal('hidden');
+      hlsAdapterInstance._videoElement.textTracks[i].mode.should.equal('disabled');
     }
   });
 
@@ -216,7 +216,7 @@ describe('HlsAdapter Instance - Unit', function () {
     hlsAdapterInstance._videoElement.textTracks[0].mode = 'showing';
     hlsAdapterInstance.hideTextTrack();
     for (let i = 0; i < hlsAdapterInstance._videoElement.textTracks.length; i++) {
-      hlsAdapterInstance._videoElement.textTracks[i].mode.should.equal('hidden');
+      hlsAdapterInstance._videoElement.textTracks[i].mode.should.equal('disabled');
     }
   });
 


### PR DESCRIPTION
### Description of the Changes

align with playkit-js caption refactor
need to hide native text tracks and use emulated display via HTML because not all browsers support all TextTrack API or VTTCue as defined by spec

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
