### PR TITLE
fix(fec-7323): captions remains from previous video

### DIFF
--- a/src/hls-adapter.js
+++ b/src/hls-adapter.js
@@ -176,6 +176,7 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
     return super.destroy().then(() => {
       HlsAdapter._logger.debug('destroy');
       this._loadPromise = null;
+      this._playerTracks = [];
       this._removeBindings();
       this._hls.detachMedia();
       this._hls.destroy();
@@ -191,7 +192,7 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
   _parseTracks(data: any): Array<Track> {
     let audioTracks = this._parseAudioTracks(data.audioTracks || []);
     let videoTracks = this._parseVideoTracks(data.levels || []);
-    let textTracks = this._parseTextTracks(this._videoElement.textTracks || []);
+    let textTracks = this._parseTextTracks(this._hls.subtitleTracks|| []);
     return audioTracks.concat(videoTracks).concat(textTracks);
   }
 
@@ -242,20 +243,21 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
   }
 
   /**
-   * Parse native video tag text tracks into player text tracks.
-   * @param {TextTrackList} vidTextTracks - The native video tag text tracks.
+   * Parse hls text tracks into player text tracks.
+   * @param {Array<Object>} hlsTextTracks - The hls text tracks.
    * @returns {Array<TextTrack>} - The parsed text tracks.
    * @private
    */
-  _parseTextTracks(vidTextTracks: TextTrackList | Array<Object>): Array<TextTrack> {
+  _parseTextTracks(hlsTextTracks: Array<Object>): Array<TextTrack> {
     let textTracks = [];
-    for (let i = 0; i < vidTextTracks.length; i++) {
+    for (let i = 0; i < hlsTextTracks.length; i++) {
       // Create text tracks
       let settings = {
-        active: vidTextTracks[i].mode === 'showing',
-        label: vidTextTracks[i].label,
-        kind: vidTextTracks[i].kind,
-        language: vidTextTracks[i].language,
+        id: hlsTextTracks[i].id,
+        active: hlsTextTracks[i].default,
+        label: hlsTextTracks[i].name,
+        kind: hlsTextTracks[i].type.toLowerCase(),
+        language: hlsTextTracks[i].lang,
         index: i
       };
       textTracks.push(new TextTrack(settings));

--- a/test/src/hls-adapter.spec.js
+++ b/test/src/hls-adapter.spec.js
@@ -191,6 +191,7 @@ describe('HlsAdapter Instance - Unit', function () {
       textTracks: hls_tracks.subtitles
     };
     hlsAdapterInstance._hls = {
+      subtitleTracks: hls_tracks.subtitles,
       audioTrack: 1,
       startLevel: 1,
       detachMedia: function () {
@@ -631,6 +632,46 @@ describe('HlsAdapter Instance - _getLiveEdge', function () {
         } else {
           hlsAdapterInstance._getLiveEdge().should.be.equal(0);
         }
+      });
+    });
+  });
+});
+
+describe('HlsAdapter Instance - change media', function () {
+
+  let hlsAdapterInstance;
+  let video;
+  let source1 = hls_sources.ElephantsDream;
+  let source2 = hls_sources.BigBugBunnuy;
+  let config;
+  let sandbox;
+
+  beforeEach(function () {
+    sandbox = sinon.sandbox.create();
+    video = document.createElement('video');
+    config = {playback: {options: {html5: {hls: {}}}}};
+  });
+
+  afterEach(function (done) {
+    sandbox.restore();
+    hlsAdapterInstance.destroy().then(() => {
+      hlsAdapterInstance = null;
+      video = null;
+      TestUtils.removeVideoElementsFromTestPage();
+      done();
+    });
+  });
+
+  it('should clean the text tracks on change media', (done) => {
+    hlsAdapterInstance = HlsAdapter.createAdapter(video, source1, config);
+    hlsAdapterInstance.load().then((data) => {
+      data.tracks.filter((track) => track instanceof TextTrack).length.should.equal(6);
+      hlsAdapterInstance.destroy().then(() => {
+        hlsAdapterInstance = HlsAdapter.createAdapter(video, source2, config);
+        hlsAdapterInstance.load().then((data) => {
+          data.tracks.filter((track) => track instanceof TextTrack).length.should.equal(0);
+          done();
+        });
       });
     });
   });

--- a/test/src/json/hls_tracks.json
+++ b/test/src/json/hls_tracks.json
@@ -119,53 +119,46 @@
   ],
   "subtitles": [
     {
-      "id": "",
-      "kind": "metadata",
-      "label": "id3",
-      "language": "",
-      "mode": "hidden"
+      "id": 0,
+      "default": false,
+      "type": "SUBTITLES",
+      "name": "Chinese",
+      "lang": "zho"
     },
     {
-      "id": "",
-      "kind": "subtitles",
-      "label": "Chinese",
-      "language": "zho",
-      "mode": "hidden"
+      "id": 1,
+      "default": false,
+      "type": "SUBTITLES",
+      "name": "Chinese",
+      "lang": "zho"
     },
     {
-      "id": "",
-      "kind": "subtitles",
-      "label": "Chinese",
-      "language": "zho",
-      "mode": "hidden"
+      "id": 2,
+      "default": true,
+      "type": "SUBTITLES",
+      "name": "French",
+      "lang": "fra"
     },
     {
-      "id": "",
-      "kind": "subtitles",
-      "label": "French",
-      "language": "fra",
-      "mode": "showing"
+      "id": 3,
+      "default": false,
+      "type": "SUBTITLES",
+      "name": "German",
+      "lang": "deu"
     },
     {
-      "id": "",
-      "kind": "subtitles",
-      "label": "German",
-      "language": "deu",
-      "mode": "hidden"
+      "id": 4,
+      "default": false,
+      "type": "SUBTITLES",
+      "name": "Portuguese",
+      "lang": "por"
     },
     {
-      "id": "",
-      "kind": "subtitles",
-      "label": "Portuguese",
-      "language": "por",
-      "mode": "hidden"
-    },
-    {
-      "id": "",
-      "kind": "subtitles",
-      "label": "Spanish; Castilian",
-      "language": "spa",
-      "mode": "hidden"
+      "id": 5,
+      "default": false,
+      "type": "SUBTITLES",
+      "name": "Spanish; Castilian",
+      "lang": "spa"
     }
   ]
 }

--- a/test/src/json/player_tracks.json
+++ b/test/src/json/player_tracks.json
@@ -62,13 +62,15 @@
   ],
   "textTracks": [
     {
+      "_id": 0,
       "_active": false,
-      "_label": "id3",
-      "_language": "",
+      "_label": "Chinese",
+      "_language": "zho",
       "_index": 0,
-      "_kind": "metadata"
+      "_kind": "subtitles"
     },
     {
+      "_id": 1,
       "_active": false,
       "_label": "Chinese",
       "_language": "zho",
@@ -76,38 +78,35 @@
       "_kind": "subtitles"
     },
     {
-      "_active": false,
-      "_label": "Chinese",
-      "_language": "zho",
+      "_id": 2,
+      "_active": true,
+      "_label": "French",
+      "_language": "fra",
       "_index": 2,
       "_kind": "subtitles"
     },
     {
-      "_active": true,
-      "_label": "French",
-      "_language": "fra",
+      "_id": 3,
+      "_active": false,
+      "_label": "German",
+      "_language": "deu",
       "_index": 3,
       "_kind": "subtitles"
     },
     {
+      "_id": 4,
       "_active": false,
-      "_label": "German",
-      "_language": "deu",
+      "_label": "Portuguese",
+      "_language": "por",
       "_index": 4,
       "_kind": "subtitles"
     },
     {
-      "_active": false,
-      "_label": "Portuguese",
-      "_language": "por",
-      "_index": 5,
-      "_kind": "subtitles"
-    },
-    {
+      "_id": 5,
       "_active": false,
       "_label": "Spanish; Castilian",
       "_language": "spa",
-      "_index": 6,
+      "_index": 5,
       "_kind": "subtitles"
     }
   ]


### PR DESCRIPTION
### Description of the Changes

use hlsjs api to get the subtitles, instead of video element api, which remains the tracks from previous playback.

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [x] test are passing in local environment 
- [x] Travis tests are passing (or test results are not worse than on master branch :))
- [x] Docs have been updated
