### PR TITLE
fix(FEC-7873): player shows audio and video flavour and in case of choosing audio flavour player stuck

### DIFF
--- a/src/hls-adapter.js
+++ b/src/hls-adapter.js
@@ -204,12 +204,11 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
 
   /**
    * Parse the hls tracks into player tracks.
-   * @param {any} data - The event data.
    * @returns {Array<Track>} - The parsed tracks.
    * @private
    */
-  _parseTracks(data: any): Array<Track> {
-    const audioTracks = this._parseAudioTracks(data.audioTracks || []);
+  _parseTracks(): Array<Track> {
+    const audioTracks = this._parseAudioTracks(this._hls.audioTracks || []);
     const videoTracks = this._parseVideoTracks(this._hls.levels || []);
     const textTracks = this._parseTextTracks(this._hls.subtitleTracks || []);
     return audioTracks.concat(videoTracks).concat(textTracks);
@@ -411,15 +410,13 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
   /**
    * Fired after manifest has been loaded.
    * @function _onManifestLoaded
-   * @param {string} event - The event name.
-   * @param {any} data - The event data object.
    * @private
    * @returns {void}
    */
-  _onManifestLoaded(event: string, data: any): void {
+  _onManifestLoaded(): void {
     HlsAdapter._logger.debug('The source has been loaded successfully');
     this._hls.startLoad();
-    this._playerTracks = this._parseTracks(data);
+    this._playerTracks = this._parseTracks();
   }
 
   /**

--- a/src/hls-adapter.js
+++ b/src/hls-adapter.js
@@ -209,9 +209,9 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
    * @private
    */
   _parseTracks(data: any): Array<Track> {
-    let audioTracks = this._parseAudioTracks(data.audioTracks || []);
-    let videoTracks = this._parseVideoTracks(data.levels || []);
-    let textTracks = this._parseTextTracks(this._hls.subtitleTracks || []);
+    const audioTracks = this._parseAudioTracks(data.audioTracks || []);
+    const videoTracks = this._parseVideoTracks(this._hls.levels || []);
+    const textTracks = this._parseTextTracks(this._hls.subtitleTracks || []);
     return audioTracks.concat(videoTracks).concat(textTracks);
   }
 

--- a/test/src/hls-adapter.spec.js
+++ b/test/src/hls-adapter.spec.js
@@ -184,14 +184,14 @@ describe('HlsAdapter Instance - Unit', function () {
 
   it('should parse all hls tracks into player tracks', function () {
     let data = {
-      audioTracks: hls_tracks.audioTracks,
-      levels: hls_tracks.levels
+      audioTracks: hls_tracks.audioTracks
     };
     hlsAdapterInstance._videoElement = {
       textTracks: hls_tracks.subtitles
     };
     hlsAdapterInstance._hls = {
       subtitleTracks: hls_tracks.subtitles,
+      levels: hls_tracks.levels,
       audioTrack: 1,
       startLevel: 1,
       detachMedia: function () {

--- a/test/src/hls-adapter.spec.js
+++ b/test/src/hls-adapter.spec.js
@@ -183,13 +183,11 @@ describe('HlsAdapter Instance - Unit', function () {
   });
 
   it('should parse all hls tracks into player tracks', function () {
-    let data = {
-      audioTracks: hls_tracks.audioTracks
-    };
     hlsAdapterInstance._videoElement = {
       textTracks: hls_tracks.subtitles
     };
     hlsAdapterInstance._hls = {
+      audioTracks: hls_tracks.audioTracks,
       subtitleTracks: hls_tracks.subtitles,
       levels: hls_tracks.levels,
       audioTrack: 1,
@@ -202,7 +200,7 @@ describe('HlsAdapter Instance - Unit', function () {
       off: function () {
       }
     };
-    let tracks = hlsAdapterInstance._parseTracks(data);
+    let tracks = hlsAdapterInstance._parseTracks();
     let allTracks = player_tracks.audioTracks.concat(player_tracks.videoTracks).concat(player_tracks.textTracks);
     JSON.parse(JSON.stringify(tracks)).should.deep.equal(allTracks);
   });


### PR DESCRIPTION
### Description of the Changes

Send the hls `this` levels instead of the event data levels (the `this._hls.levels` are the filtered levels from the ManifestParsed event (MANIFEST_PARSED sent before MANIFEST_LOADED).

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [x] test are passing in local environment 
- [x] Travis tests are passing (or test results are not worse than on master branch :))
- [x] Docs have been updated
