### PR TITLE
fix(FEC-7896): endless spinner appears right after changing audio track in IE and Edge

### DIFF
--- a/src/hls-adapter.js
+++ b/src/hls-adapter.js
@@ -459,7 +459,7 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
    * @returns {void}
    * @private
    */
-  _handleWaitingUponAudioTrackSwitch(): void{
+  _handleWaitingUponAudioTrackSwitch(): void {
     const affectedBrowsers = ['IE', 'Edge'];
     if (affectedBrowsers.includes(Env.browser.name)) {
       const timeUpdateListener = () => {

--- a/src/hls-adapter.js
+++ b/src/hls-adapter.js
@@ -463,7 +463,7 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
     const affectedBrowsers = ['IE', 'Edge'];
     if (affectedBrowsers.includes(Env.browser.name)) {
       const timeUpdateListener = () => {
-        this._videoElement.dispatchEvent(new Event(BaseMediaSourceAdapter.Html5Events.PLAYING));
+        this._trigger(BaseMediaSourceAdapter.Html5Events.PLAYING);
         this._videoElement.removeEventListener(BaseMediaSourceAdapter.Html5Events.TIME_UPDATE, timeUpdateListener);
       }
       this._videoElement.addEventListener(BaseMediaSourceAdapter.Html5Events.TIME_UPDATE, timeUpdateListener)

--- a/src/hls-adapter.js
+++ b/src/hls-adapter.js
@@ -449,6 +449,22 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
     });
     HlsAdapter._logger.debug('Audio track changed', audioTrack);
     this._onTrackChanged(audioTrack);
+    this._handleWaitingUponAudioTrackSwitch();
+  }
+
+  /**
+   * Trigger a playing event whenever an audio track is changed & time_update event is fired.
+   * This align Edge and IE behaviour to other browsers. When an audio track changed in IE & Edge, they trigger
+   * waiting event but not playing event.
+   * @returns {void}
+   * @private
+   */
+  _handleWaitingUponAudioTrackSwitch(): void{
+    const timeUpdateListener = () => {
+      this._videoElement.dispatchEvent(new Event(BaseMediaSourceAdapter.Html5Events.PLAYING));
+      this._videoElement.removeEventListener(BaseMediaSourceAdapter.Html5Events.TIME_UPDATE, timeUpdateListener);
+    }
+    this._videoElement.addEventListener(BaseMediaSourceAdapter.Html5Events.TIME_UPDATE, timeUpdateListener)
   }
 
   /**

--- a/src/hls-adapter.js
+++ b/src/hls-adapter.js
@@ -2,7 +2,7 @@
 import Hlsjs from 'hls.js'
 import DefaultConfig from './default-config'
 import {HlsJsErrorMap, type ErrorDetailsType} from "./errors"
-import {BaseMediaSourceAdapter, Utils, Error} from 'playkit-js'
+import {BaseMediaSourceAdapter, Utils, Error, Env} from 'playkit-js'
 import {Track, VideoTrack, AudioTrack, TextTrack} from 'playkit-js'
 
 /**
@@ -460,11 +460,14 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
    * @private
    */
   _handleWaitingUponAudioTrackSwitch(): void{
-    const timeUpdateListener = () => {
-      this._videoElement.dispatchEvent(new Event(BaseMediaSourceAdapter.Html5Events.PLAYING));
-      this._videoElement.removeEventListener(BaseMediaSourceAdapter.Html5Events.TIME_UPDATE, timeUpdateListener);
+    const affectedBrowsers = ['IE', 'Edge'];
+    if (affectedBrowsers.includes(Env.browser.name)) {
+      const timeUpdateListener = () => {
+        this._videoElement.dispatchEvent(new Event(BaseMediaSourceAdapter.Html5Events.PLAYING));
+        this._videoElement.removeEventListener(BaseMediaSourceAdapter.Html5Events.TIME_UPDATE, timeUpdateListener);
+      }
+      this._videoElement.addEventListener(BaseMediaSourceAdapter.Html5Events.TIME_UPDATE, timeUpdateListener)
     }
-    this._videoElement.addEventListener(BaseMediaSourceAdapter.Html5Events.TIME_UPDATE, timeUpdateListener)
   }
 
   /**


### PR DESCRIPTION
### Description of the Changes

Handling a situation after audio track is changed, only in IE and Edge.
If a waiting event is sent, we send playing event.

@dan-ziv, I didn't use the event manager i thought it's an overkill, cause it's not imported anyway.. let me know if you think otherwise.

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
