### PR TITLE
fix(FEC-7913): Live - player doesn't seek to live edge on resume

### DIFF
--- a/src/hls-adapter.js
+++ b/src/hls-adapter.js
@@ -371,7 +371,7 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
       if (this._hls.config.liveSyncDuration) {
         liveEdge = this._videoElement.duration - this._hls.config.liveSyncDuration;
       } else {
-        liveEdge = this._videoElement.duration - this._hls.config.liveSyncDurationCount * this._hls.levels[0].details.targetduration;
+        liveEdge = this._videoElement.duration - this._hls.config.liveSyncDurationCount * this._hls.levels[this._hls.currentLevel].details.targetduration;
       }
       return liveEdge > 0 ? liveEdge : 0;
     } catch (e) {
@@ -401,7 +401,7 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
    */
   isLive(): boolean {
     try {
-      return this._hls.levels[0].details.live;
+      return this._hls.levels[this._hls.currentLevel].details.live;
     } catch (e) {
       return false;
     }

--- a/src/hls-adapter.js
+++ b/src/hls-adapter.js
@@ -375,7 +375,7 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
       }
       return liveEdge > 0 ? liveEdge : 0;
     } catch (e) {
-      return NaN;
+      return this._videoElement.duration;
     }
   }
 

--- a/src/hls-adapter.js
+++ b/src/hls-adapter.js
@@ -361,6 +361,18 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
   }
 
   /**
+   * Returns the details of hls level
+   * @function _getDetails
+   * @returns {Object} - Level details
+   * @private
+   */
+  _getDetails(): Object {
+    const level = this._hls.levels[this._hls.currentLevel] || this._hls.levels[this._hls.nextLevel] || this._hls.levels[this._hls.nextAutoLevel] || this._hls.levels[this._hls.nextLoadLevel];
+    return level ? level.details : {};
+  }
+
+
+  /**
    * Returns the live edge
    * @returns {number} - live edge
    * @private
@@ -371,7 +383,7 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
       if (this._hls.config.liveSyncDuration) {
         liveEdge = this._videoElement.duration - this._hls.config.liveSyncDuration;
       } else {
-        liveEdge = this._videoElement.duration - this._hls.config.liveSyncDurationCount * this._hls.levels[this._hls.currentLevel].details.targetduration;
+        liveEdge = this._videoElement.duration - this._hls.config.liveSyncDurationCount * this._getDetails().targetduration;
       }
       return liveEdge > 0 ? liveEdge : 0;
     } catch (e) {
@@ -401,7 +413,7 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
    */
   isLive(): boolean {
     try {
-      return this._hls.levels[this._hls.currentLevel].details.live;
+      return this._getDetails().live;
     } catch (e) {
       return false;
     }

--- a/src/hls-adapter.js
+++ b/src/hls-adapter.js
@@ -380,12 +380,14 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
   _getLiveEdge(): number {
     try {
       let liveEdge;
-      if (this._hls.config.liveSyncDuration) {
+      if (this._hls.liveSyncPosition) {
+        liveEdge = this._hls.liveSyncPosition;
+      } else if (this._hls.config.liveSyncDuration) {
         liveEdge = this._videoElement.duration - this._hls.config.liveSyncDuration;
       } else {
         liveEdge = this._videoElement.duration - this._hls.config.liveSyncDurationCount * this._getLevelDetails().targetduration;
       }
-      return liveEdge > 0 ? liveEdge : 0;
+      return liveEdge > 0 ? liveEdge : this._videoElement.duration;
     } catch (e) {
       return this._videoElement.duration;
     }

--- a/src/hls-adapter.js
+++ b/src/hls-adapter.js
@@ -362,11 +362,11 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
 
   /**
    * Returns the details of hls level
-   * @function _getDetails
+   * @function _getLevelDetails
    * @returns {Object} - Level details
    * @private
    */
-  _getDetails(): Object {
+  _getLevelDetails(): Object {
     const level = this._hls.levels[this._hls.currentLevel] || this._hls.levels[this._hls.nextLevel] || this._hls.levels[this._hls.nextAutoLevel] || this._hls.levels[this._hls.nextLoadLevel];
     return level ? level.details : {};
   }
@@ -383,7 +383,7 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
       if (this._hls.config.liveSyncDuration) {
         liveEdge = this._videoElement.duration - this._hls.config.liveSyncDuration;
       } else {
-        liveEdge = this._videoElement.duration - this._hls.config.liveSyncDurationCount * this._getDetails().targetduration;
+        liveEdge = this._videoElement.duration - this._hls.config.liveSyncDurationCount * this._getLevelDetails().targetduration;
       }
       return liveEdge > 0 ? liveEdge : 0;
     } catch (e) {
@@ -413,7 +413,7 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
    */
   isLive(): boolean {
     try {
-      return this._getDetails().live;
+      return this._getLevelDetails().live;
     } catch (e) {
       return false;
     }

--- a/test/src/hls-adapter.spec.js
+++ b/test/src/hls-adapter.spec.js
@@ -551,32 +551,15 @@ describe('HlsAdapter Instance - _getLiveEdge', function () {
     });
   });
 
-  it('should return live edge for liveSyncDuration = 60', (done) => {
-    config.playback.options.html5.hls.liveSyncDuration = 60;
+  it('should return live edge', (done) => {
     hlsAdapterInstance = HlsAdapter.createAdapter(video, liveSource, config);
     hlsAdapterInstance.load().then(() => {
       hlsAdapterInstance._videoElement.addEventListener('durationchange', () => {
-        if (video.duration > 60) {
-          hlsAdapterInstance._getLiveEdge().should.be.equal(video.duration - 60);
+        if (hlsAdapterInstance._hls.liveSyncPosition) {
+          hlsAdapterInstance._getLiveEdge().should.be.equal(hlsAdapterInstance._hls.liveSyncPosition);
           done();
         } else {
-          hlsAdapterInstance._getLiveEdge().should.be.equal(0);
-        }
-      });
-    });
-  });
-
-  it('should return live edge for liveSyncDurationCount = 5', (done) => {
-    config.playback.options.html5.hls.liveSyncDurationCount = 5;
-    hlsAdapterInstance = HlsAdapter.createAdapter(video, liveSource, config);
-    hlsAdapterInstance.load().then(() => {
-      hlsAdapterInstance._videoElement.addEventListener('durationchange', () => {
-        let delay = 5 * hlsAdapterInstance._getLevelDetails().targetduration;
-        if (video.duration > delay) {
-          hlsAdapterInstance._getLiveEdge().should.be.equal(video.duration - delay);
-          done();
-        } else {
-          hlsAdapterInstance._getLiveEdge().should.be.equal(0);
+          hlsAdapterInstance._getLiveEdge().should.be.equal(video.duration);
         }
       });
     });

--- a/test/src/hls-adapter.spec.js
+++ b/test/src/hls-adapter.spec.js
@@ -571,7 +571,7 @@ describe('HlsAdapter Instance - _getLiveEdge', function () {
     hlsAdapterInstance = HlsAdapter.createAdapter(video, liveSource, config);
     hlsAdapterInstance.load().then(() => {
       hlsAdapterInstance._videoElement.addEventListener('durationchange', () => {
-        let delay = 5 * hlsAdapterInstance._getDetails().targetduration;
+        let delay = 5 * hlsAdapterInstance._getLevelDetails().targetduration;
         if (video.duration > delay) {
           hlsAdapterInstance._getLiveEdge().should.be.equal(video.duration - delay);
           done();

--- a/test/src/hls-adapter.spec.js
+++ b/test/src/hls-adapter.spec.js
@@ -571,7 +571,7 @@ describe('HlsAdapter Instance - _getLiveEdge', function () {
     hlsAdapterInstance = HlsAdapter.createAdapter(video, liveSource, config);
     hlsAdapterInstance.load().then(() => {
       hlsAdapterInstance._videoElement.addEventListener('durationchange', () => {
-        let delay = 5 * hlsAdapterInstance._hls.levels[0].details.targetduration;
+        let delay = 5 * hlsAdapterInstance._getDetails().targetduration;
         if (video.duration > delay) {
           hlsAdapterInstance._getLiveEdge().should.be.equal(video.duration - delay);
           done();


### PR DESCRIPTION
### Description of the Changes
live edge calculation refactor:
* use `hls.liveSyncPosition` if available
* use the `hls.currentLevel` property to get data of the current level instead of getting the index 0 level Arbitrarily.
* if any calculation is unavailable return the duration 

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [x] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [x] Docs have been updated
