### PR TITLE
fix(FEC-7623): preset captions are no displayed

### DIFF
--- a/src/hls-adapter.js
+++ b/src/hls-adapter.js
@@ -168,9 +168,7 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
   load(startTime: ?number): Promise<Object> {
     if (!this._loadPromise) {
       this._loadPromise = new Promise((resolve) => {
-        this._videoElement.addEventListener(EventType.LOADED_METADATA, () => {
-          resolve({tracks: this._playerTracks});
-        });
+        this._videoElement.addEventListener(EventType.LOADED_METADATA, () => resolve({tracks: this._playerTracks}));
         if (startTime) {
           this._hls.startPosition = startTime;
         }

--- a/src/hls-adapter.js
+++ b/src/hls-adapter.js
@@ -4,6 +4,7 @@ import DefaultConfig from './default-config'
 import {HlsJsErrorMap, type ErrorDetailsType} from "./errors"
 import {BaseMediaSourceAdapter, Utils, Error, Env} from 'playkit-js'
 import {Track, VideoTrack, AudioTrack, TextTrack} from 'playkit-js'
+import {EventType} from 'playkit-js'
 
 /**
  * Adapter of hls.js lib for hls content.
@@ -167,11 +168,9 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
   load(startTime: ?number): Promise<Object> {
     if (!this._loadPromise) {
       this._loadPromise = new Promise((resolve) => {
-        let onLevelUpdated = () => {
-          this._hls.off(Hlsjs.Events.LEVEL_UPDATED, onLevelUpdated);
+        this._videoElement.addEventListener(EventType.LOADED_METADATA, () => {
           resolve({tracks: this._playerTracks});
-        };
-        this._hls.on(Hlsjs.Events.LEVEL_UPDATED, onLevelUpdated);
+        });
         if (startTime) {
           this._hls.startPosition = startTime;
         }


### PR DESCRIPTION
### Description of the Changes

Resolving the load promise only on `metadataloaded` html5 event, 
not on `LEVEL_UPDATED` hls event which is too early for text track selection.

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [x] test are passing in local environment 
- [x] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
