### PR TITLE
fix: remove loadedmetadata listener once metadata loaded

### DIFF
--- a/src/hls-adapter.js
+++ b/src/hls-adapter.js
@@ -203,6 +203,11 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
     resolve({tracks: this._playerTracks});
   }
 
+  /**
+   * Remove the loadedmetadata listener
+   * @private
+   * @returns {void}
+   */
   _removeLoadedMetadataListener(): void {
     if (this._onLoadedMetadataCallback) {
       this._videoElement.removeEventListener(EventType.LOADED_METADATA, this._onLoadedMetadataCallback);

--- a/src/hls-adapter.js
+++ b/src/hls-adapter.js
@@ -168,7 +168,11 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
   load(startTime: ?number): Promise<Object> {
     if (!this._loadPromise) {
       this._loadPromise = new Promise((resolve) => {
-        this._videoElement.addEventListener(EventType.LOADED_METADATA, () => resolve({tracks: this._playerTracks}));
+        const onLoadedMetadata = () => {
+          this._videoElement.removeEventListener(EventType.LOADED_METADATA, onLoadedMetadata);
+          resolve({tracks: this._playerTracks});
+        };
+        this._videoElement.addEventListener(EventType.LOADED_METADATA, onLoadedMetadata);
         if (startTime) {
           this._hls.startPosition = startTime;
         }
@@ -477,7 +481,7 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
       const timeUpdateListener = () => {
         this._trigger(EventType.PLAYING);
         this._videoElement.removeEventListener(EventType.TIME_UPDATE, timeUpdateListener);
-      }
+      };
       this._videoElement.addEventListener(EventType.TIME_UPDATE, timeUpdateListener)
     }
   }

--- a/src/hls-adapter.js
+++ b/src/hls-adapter.js
@@ -199,11 +199,15 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
    * @returns {void}
    */
   _onLoadedMetadata(resolve: Function): void {
+    this._removeLoadedMetadataListener();
+    resolve({tracks: this._playerTracks});
+  }
+
+  _removeLoadedMetadataListener(): void {
     if (this._onLoadedMetadataCallback) {
       this._videoElement.removeEventListener(EventType.LOADED_METADATA, this._onLoadedMetadataCallback);
       this._onLoadedMetadataCallback = null;
     }
-    resolve({tracks: this._playerTracks});
   }
 
   /**
@@ -640,10 +644,7 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
     this._hls.off(Hlsjs.Events.ERROR, this._onError);
     this._hls.off(Hlsjs.Events.LEVEL_SWITCHED, this._onLevelSwitched);
     this._hls.off(Hlsjs.Events.AUDIO_TRACK_SWITCHED, this._onAudioTrackSwitched);
-    if (this._onLoadedMetadataCallback) {
-      this._videoElement.removeEventListener(EventType.LOADED_METADATA, this._onLoadedMetadataCallback);
-      this._onLoadedMetadataCallback = null;
-    }
+    this._removeLoadedMetadataListener();
   }
 
   /**


### PR DESCRIPTION
### Description of the Changes
since we resolve the ready promise with `loadedmetadata` event listener [here](https://github.com/kaltura/playkit-js-hls/pull/50) 
we have to remove this listener once the metadata is loaded or on destroy for change media flow
### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [x] test are passing in local environment 
- [x] Travis tests are passing (or test results are not worse than on master branch :))
- [x] Docs have been updated
