### PR TITLE
expose Hls.js global to allow plugin interaction

### DIFF
--- a/src/hls-adapter.js
+++ b/src/hls-adapter.js
@@ -15,6 +15,9 @@ import {
 } from 'playkit-js'
 import pLoader from './jsonp-ploader'
 
+// expose Hls.js's global to allow plugins interaction
+window.Hls = Hlsjs;
+
 /**
  * Adapter of hls.js lib for hls content.
  * @classdesc

--- a/test/src/hls-adapter.spec.js
+++ b/test/src/hls-adapter.spec.js
@@ -9,6 +9,12 @@ import {EventType} from 'playkit-js'
 
 const targetId = 'player-placeholder_hls-adapter.spec';
 
+describe('HlsAdapter', function () {
+  it('should expose Hls to window', function () {
+    window.Hls.should.be.ok;
+  });
+});
+
 describe('HlsAdapter.canPlayDrm', function () {
   it('should return false for any input', function () {
     HlsAdapter.canPlayDrm().should.be.false;


### PR DESCRIPTION
### Description of the Changes

Some Hlsjs plugins rely on the existence of the `Hls` global.
exposing it will allow extending playkit-js-hls rather than writing another hls implementation.

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [x] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
