### PR TITLE
fix(FEC-8396): media source adapters default config overrides the player supplied config

### DIFF
--- a/src/hls-adapter.js
+++ b/src/hls-adapter.js
@@ -197,7 +197,7 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
   constructor(videoElement: HTMLVideoElement, source: PKMediaSourceObject, config: Object) {
     HlsAdapter._logger.debug('Creating adapter. Hls version: ' + Hlsjs.version);
     super(videoElement, source, config);
-    this._config = Utils.Object.mergeDeep({}, this._config, DefaultConfig);
+    this._config = Utils.Object.mergeDeep({}, DefaultConfig, this._config);
     if (this._config.forceRedirectExternalStreams) {
       this._config.hlsConfig['pLoader'] = pLoader;
     }


### PR DESCRIPTION
### Description of the Changes

The merge order for the config gave default config precedence over the application supplied config

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
