### PR TITLE
feat(FEC-8390, FEC-8246): support 608/708 captions

### DIFF
--- a/src/hls-adapter.js
+++ b/src/hls-adapter.js
@@ -155,17 +155,17 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
     if (Utils.Object.hasPropertyPath(config, 'playback.enableCEACaptions')) {
       adapterConfig.hlsConfig.enableCEA708Captions = config.playback.enableCEACaptions;
     }
-    if (Utils.Object.hasPropertyPath(config, 'playback.captionsTextTrack1Label')) {
-      adapterConfig.hlsConfig.captionsTextTrack1Label = config.playback.captionsTextTrack1Label;
+    if (Utils.Object.hasPropertyPath(config, 'playback.CEACaptions1Label')) {
+      adapterConfig.hlsConfig.captionsTextTrack1Label = config.playback.CEACaptions1Label;
     }
-    if (Utils.Object.hasPropertyPath(config, 'playback.captionsTextTrack1LanguageCode')) {
-      adapterConfig.hlsConfig.captionsTextTrack1LanguageCode = config.playback.captionsTextTrack1LanguageCode;
+    if (Utils.Object.hasPropertyPath(config, 'playback.CEACaptions1LanguageCode')) {
+      adapterConfig.hlsConfig.captionsTextTrack1LanguageCode = config.playback.CEACaptions1LanguageCode;
     }
-    if (Utils.Object.hasPropertyPath(config, 'playback.captionsTextTrack2Label')) {
-      adapterConfig.hlsConfig.captionsTextTrack2Label = config.playback.captionsTextTrack2Label;
+    if (Utils.Object.hasPropertyPath(config, 'playback.CEACaptions2Label')) {
+      adapterConfig.hlsConfig.captionsTextTrack2Label = config.playback.CEACaptions2Label;
     }
-    if (Utils.Object.hasPropertyPath(config, 'playback.captionsTextTrack2LanguageCode')) {
-      adapterConfig.hlsConfig.captionsTextTrack2LanguageCode = config.playback.captionsTextTrack2LanguageCode;
+    if (Utils.Object.hasPropertyPath(config, 'playback.CEACaptions2LanguageCode')) {
+      adapterConfig.hlsConfig.captionsTextTrack2LanguageCode = config.playback.CEACaptions2LanguageCode;
     }
     return new this(videoElement, source, adapterConfig);
   }

--- a/src/hls-adapter.js
+++ b/src/hls-adapter.js
@@ -152,21 +152,11 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
     if (Utils.Object.hasPropertyPath(config, 'playback.useNativeTextTrack')) {
       adapterConfig.subtitleDisplay = Utils.Object.getPropertyPath(config, 'playback.useNativeTextTrack');
     }
-    if (Utils.Object.hasPropertyPath(config, 'playback.enableCEA708Captions')) {
-      adapterConfig.hlsConfig.enableCEA708Captions = config.playback.enableCEA708Captions;
-    }
-    if (Utils.Object.hasPropertyPath(config, 'playback.captionsTextTrack1Label')) {
-      adapterConfig.hlsConfig.captionsTextTrack1Label = config.playback.captionsTextTrack1Label;
-    }
-    if (Utils.Object.hasPropertyPath(config, 'playback.captionsTextTrack1LanguageCode')) {
-      adapterConfig.hlsConfig.captionsTextTrack1LanguageCode = config.playback.captionsTextTrack1LanguageCode;
-    }
-    if (Utils.Object.hasPropertyPath(config, 'playback.captionsTextTrack2Label')) {
-      adapterConfig.hlsConfig.captionsTextTrack2Label = config.playback.captionsTextTrack2Label;
-    }
-    if (Utils.Object.hasPropertyPath(config, 'playback.captionsTextTrack2LanguageCode')) {
-      adapterConfig.hlsConfig.captionsTextTrack2LanguageCode = config.playback.captionsTextTrack2LanguageCode;
-    }
+    adapterConfig.hlsConfig.enableCEA708Captions = config.playback.enableCEA708Captions;
+    adapterConfig.hlsConfig.captionsTextTrack1Label = config.playback.captionsTextTrack1Label;
+    adapterConfig.hlsConfig.captionsTextTrack1LanguageCode = config.playback.captionsTextTrack1LanguageCode;
+    adapterConfig.hlsConfig.captionsTextTrack2Label = config.playback.captionsTextTrack2Label;
+    adapterConfig.hlsConfig.captionsTextTrack2LanguageCode = config.playback.captionsTextTrack2LanguageCode;
     return new this(videoElement, source, adapterConfig);
   }
 

--- a/src/hls-adapter.js
+++ b/src/hls-adapter.js
@@ -574,7 +574,11 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
    * @public
    */
   hideTextTrack(): void {
-    this._hls.subtitleTrack = -1;
+    if (this._hls.subtitleTracks.length) {
+      this._hls.subtitleTrack = -1;
+    } else {
+      this._disableNativeTextTracks();
+    }
   }
 
   /**

--- a/src/hls-adapter.js
+++ b/src/hls-adapter.js
@@ -474,7 +474,7 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
         label: CEATextTrack.label,
         kind: CEATextTrack.kind,
         language: CEATextTrack.language,
-        index: this._playerTracks.filter((track) => track instanceof TextTrack).length
+        index: this._playerTracks.filter(track => track instanceof TextTrack).length
       };
       textTrack = new TextTrack(settings);
     }
@@ -559,7 +559,6 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
       track.mode = 'disabled';
     });
   }
-
 
   /** Hide the text track
    * @function hideTextTrack

--- a/src/hls-adapter.js
+++ b/src/hls-adapter.js
@@ -120,6 +120,7 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
    * @private
    */
   _onRecoveredCallback: ?Function;
+  _onAddTrack: Function;
 
   /**
    * Factory method to create media source adapter.

--- a/src/hls-adapter.js
+++ b/src/hls-adapter.js
@@ -489,7 +489,8 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
         active: CEATextTrack.mode === 'showing',
         label: CEATextTrack.label,
         kind: CEATextTrack.kind,
-        language: CEATextTrack.language
+        language: CEATextTrack.language,
+        index: this._playerTracks.filter((track) => track instanceof TextTrack).length
       };
       textTrack = new TextTrack(settings);
     }

--- a/src/hls-adapter.js
+++ b/src/hls-adapter.js
@@ -152,20 +152,20 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
     if (Utils.Object.hasPropertyPath(config, 'playback.useNativeTextTrack')) {
       adapterConfig.subtitleDisplay = Utils.Object.getPropertyPath(config, 'playback.useNativeTextTrack');
     }
-    if (Utils.Object.hasPropertyPath(config, 'playback.enableCEACaptions')) {
-      adapterConfig.hlsConfig.enableCEA708Captions = config.playback.enableCEACaptions;
+    if (Utils.Object.hasPropertyPath(config, 'playback.enableCEA708Captions')) {
+      adapterConfig.hlsConfig.enableCEA708Captions = config.playback.enableCEA708Captions;
     }
-    if (Utils.Object.hasPropertyPath(config, 'playback.CEACaptions1Label')) {
-      adapterConfig.hlsConfig.captionsTextTrack1Label = config.playback.CEACaptions1Label;
+    if (Utils.Object.hasPropertyPath(config, 'playback.captionsTextTrack1Label')) {
+      adapterConfig.hlsConfig.captionsTextTrack1Label = config.playback.captionsTextTrack1Label;
     }
-    if (Utils.Object.hasPropertyPath(config, 'playback.CEACaptions1LanguageCode')) {
-      adapterConfig.hlsConfig.captionsTextTrack1LanguageCode = config.playback.CEACaptions1LanguageCode;
+    if (Utils.Object.hasPropertyPath(config, 'playback.captionsTextTrack1LanguageCode')) {
+      adapterConfig.hlsConfig.captionsTextTrack1LanguageCode = config.playback.captionsTextTrack1LanguageCode;
     }
-    if (Utils.Object.hasPropertyPath(config, 'playback.CEACaptions2Label')) {
-      adapterConfig.hlsConfig.captionsTextTrack2Label = config.playback.CEACaptions2Label;
+    if (Utils.Object.hasPropertyPath(config, 'playback.captionsTextTrack2Label')) {
+      adapterConfig.hlsConfig.captionsTextTrack2Label = config.playback.captionsTextTrack2Label;
     }
-    if (Utils.Object.hasPropertyPath(config, 'playback.CEACaptions2LanguageCode')) {
-      adapterConfig.hlsConfig.captionsTextTrack2LanguageCode = config.playback.CEACaptions2LanguageCode;
+    if (Utils.Object.hasPropertyPath(config, 'playback.captionsTextTrack2LanguageCode')) {
+      adapterConfig.hlsConfig.captionsTextTrack2LanguageCode = config.playback.captionsTextTrack2LanguageCode;
     }
     return new this(videoElement, source, adapterConfig);
   }


### PR DESCRIPTION
### Description of the Changes

parse 608/708 tracks by the video element `textTrack` api
depends on 
https://github.com/kaltura/playkit-js/pull/265
https://github.com/kaltura/playkit-js-ui/pull/254 

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
