### PR TITLE
fix(FEC-8506): fail to resolve manifest load with multi-audio streams

### DIFF
--- a/src/hls-adapter.js
+++ b/src/hls-adapter.js
@@ -642,7 +642,7 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
       this._hls.startLoad(this._startTime);
     }
     this._playerTracks = this._parseTracks();
-    if (this._hls.audioTracks.length) {
+    if (this._hls.audioTracks.length > 1) {
       this._hls.once(Hlsjs.Events.AUDIO_TRACK_SWITCHING, () => {
         this._resolveLoad({tracks: this._playerTracks});
       });


### PR DESCRIPTION
### Description of the Changes

hls.js has an issue with selecting audio track before the manifest was loaded(it was solved in 0.11.0 which we haven't upgraded yet to).
To overcome the issue we added a workaround in #69  but it causes an issue, that was also fixed in 0.11.0 :-( for incorrect indexes of audio tracks when using different audio group ids.
So - this is another "fast" workaround until we upgrade to hls.js 0.11.0

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
