### PR TITLE
fix(FEC-8510): listen to the html video element error event only once

### DIFF
--- a/src/hls-adapter.js
+++ b/src/hls-adapter.js
@@ -210,8 +210,6 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
     this._hls.on(Hlsjs.Events.LEVEL_SWITCHED, this._onLevelSwitched.bind(this));
     this._hls.on(Hlsjs.Events.AUDIO_TRACK_SWITCHED, this._onAudioTrackSwitched.bind(this));
     this._onRecoveredCallback = () => this._onRecovered();
-    this._onVideoErrorCallback = e => this._onVideoError(e);
-    this._videoElement.addEventListener(EventType.ERROR, this._onVideoErrorCallback);
     this._onAddTrack = this._onAddTrack.bind(this);
     this._videoElement.addEventListener('addtrack', this._onAddTrack);
     this._videoElement.textTracks.onaddtrack = this._onAddTrack;
@@ -233,9 +231,9 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
    * video error event handler.
    * @param {Event} event - the media error event
    * @private
-   * @returns {void}
+   * @returns {boolean} if hls-adapter will try to recover
    */
-  _onVideoError(event: Event): void {
+  canRecover(event: Event): void {
     if (event.currentTarget instanceof HTMLMediaElement && event.currentTarget.error instanceof MediaError) {
       const mediaError = event.currentTarget.error;
       if (mediaError.code === mediaError.MEDIA_ERR_DECODE) {
@@ -243,7 +241,9 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
           'The video playback was aborted due to a corruption problem or because the video used features your browser did not support.',
           mediaError.message
         );
-        this._handleMediaError();
+        return this._handleMediaError();
+      } else {
+        return false;
       }
     }
   }


### PR DESCRIPTION
listening through the engine and calling canRecover instead of listening to the video element in the adapter and in the html5.js engine.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
