### PR TITLE
fix(FEC-8557): workaround for hls.js text track selection issues

### DIFF
--- a/src/hls-adapter.js
+++ b/src/hls-adapter.js
@@ -629,28 +629,31 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
     this._playerTracks = this._parseTracks();
     //TODO: workaround for various hls.js issues with the initial track selection logic.
     //TODO: once https://github.com/video-dev/hls.js/issues/1948 is solved and we move to next hls.js version we need to reomve this if clause
+    if (!this._maybeHandleInitialTracksWorkaround()) {
+      this._resolveLoad({tracks: this._playerTracks});
+    }
+  }
+
+  _maybeHandleInitialTracksWorkaround(): boolean {
     const hasDefaultTextTrack = this._hls.subtitleTracks.some(track => track.default);
     if (this._hls.audioTracks.length > 1 || hasDefaultTextTrack) {
       let numberOfEventsToWait = 0;
+      const handler = () => {
+        if (--numberOfEventsToWait == 0) {
+          this._resolveLoad({tracks: this._playerTracks});
+        }
+      };
       if (hasDefaultTextTrack) {
         numberOfEventsToWait++;
-        this._hls.once(Hlsjs.Events.SUBTITLE_FRAG_PROCESSED, () => {
-          if (--numberOfEventsToWait == 0) {
-            this._resolveLoad({tracks: this._playerTracks});
-          }
-        });
+        this._hls.once(Hlsjs.Events.SUBTITLE_FRAG_PROCESSED, handler);
       }
       if (this._hls.audioTracks.length > 1) {
         numberOfEventsToWait++;
-        this._hls.once(Hlsjs.Events.AUDIO_TRACK_SWITCHING, () => {
-          if (--numberOfEventsToWait == 0) {
-            this._resolveLoad({tracks: this._playerTracks});
-          }
-        });
+        this._hls.once(Hlsjs.Events.AUDIO_TRACK_SWITCHING, handler);
       }
-    } else {
-      this._resolveLoad({tracks: this._playerTracks});
+      return true;
     }
+    return false;
   }
 
   /**


### PR DESCRIPTION
### Description of the Changes

When we select initial captions then hls.js has an internal bug that fails.
This is a workaround until issue is fixed.
see detailed issue explainer here: https://github.com/video-dev/hls.js/issues/1948

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [x] test are passing in local environment 
