### PR TITLE
fix(FEC-8690): player stuck with endless spinner on change media

### DIFF
--- a/src/hls-adapter.js
+++ b/src/hls-adapter.js
@@ -666,6 +666,9 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
         numberOfEventsToWait++;
         this._hls.once(Hlsjs.Events.AUDIO_TRACK_SWITCHING, handler);
       }
+      setTimeout(() => {
+        this._resolveLoad({tracks: this._playerTracks});
+      }, 1000);
       return true;
     }
     return false;

--- a/src/hls-adapter.js
+++ b/src/hls-adapter.js
@@ -104,6 +104,7 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
    */
   _onRecoveredCallback: ?Function;
   _onAddTrack: Function;
+  _resolveLoadTimeout: number;
 
   /**
    * Factory method to create media source adapter.
@@ -344,6 +345,7 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
    */
   _reset(): void {
     this._removeBindings();
+    clearTimeout(this._resolveLoadTimeout);
     this._hls.detachMedia();
     this._hls.destroy();
   }
@@ -666,7 +668,7 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
         numberOfEventsToWait++;
         this._hls.once(Hlsjs.Events.AUDIO_TRACK_SWITCHING, handler);
       }
-      setTimeout(() => {
+      this._resolveLoadTimeout = setTimeout(() => {
         this._resolveLoad({tracks: this._playerTracks});
       }, 1000);
       return true;


### PR DESCRIPTION
### Description of the Changes

resolve the promise in timeout as a workaround for [hlsls issue ](https://github.com/video-dev/hls.js/issues/1948).

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
