### PR TITLE
fix(FEC-8764): after change media / refresh the video has no subtitles

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,12 +1,12 @@
 ### Description of the Changes
 
-Please add a detailed description of the change, weather it's an enhancement or a bugfix.
+Please add a detailed description of the change, whether it's an enhancement or a bugfix.
 If the PR is related to an open issue please link to it.
 
 ### CheckLists
 
 - [ ] changes have been done against master branch, and PR does not conflict
 - [ ] new unit / functional tests have been added (whenever applicable)
-- [ ] test are passing in local environment 
+- [ ] test are passing in local environment
 - [ ] Travis tests are passing (or test results are not worse than on master branch :))
 - [ ] Docs have been updated

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "eslint-plugin-mocha-no-only": "^0.0.5",
     "eslint-plugin-prettier": "^2.6.2",
     "flow-bin": "latest",
-    "hls.js": "^0.10.1",
+    "hls.js": "^0.12.0",
     "husky": "^0.14.3",
     "istanbul": "^0.4.5",
     "karma": "^1.5.0",
@@ -78,8 +78,8 @@
     "webpack-dev-server": "latest"
   },
   "peerDependencies": {
-    "hls.js": "^0.10.1",
-    "@playkit-js/playkit-js": "^0.38.0"
+    "@playkit-js/playkit-js": "^0.38.0",
+    "hls.js": "0.12.0"
   },
   "keywords": [
     "hls",

--- a/src/hls-adapter.js
+++ b/src/hls-adapter.js
@@ -105,7 +105,7 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
   _onRecoveredCallback: ?Function;
   _onAddTrack: Function;
   _resolveLoadTimeout: number;
-  _hlsMediaAttachedResolver: Function;
+  _onMediaAttached: Function;
   _mediaAttachedPromise: Promise<*>;
 
   /**
@@ -232,9 +232,6 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
     this._hls = new Hlsjs(this._config.hlsConfig);
     this._capabilities.fpsControl = true;
     this._hls.subtitleDisplay = this._config.subtitleDisplay;
-    this._mediaAttachedPromise = new Promise(resolve => {
-      this._hlsMediaAttachedResolver = resolve;
-    });
     this._addBindings();
   }
 
@@ -250,7 +247,8 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
     this._hls.on(Hlsjs.Events.LEVEL_SWITCHED, this._onLevelSwitched.bind(this));
     this._hls.on(Hlsjs.Events.AUDIO_TRACK_SWITCHED, this._onAudioTrackSwitched.bind(this));
     this._hls.on(Hlsjs.Events.FPS_DROP, (e, data) => this._onFpsDrop(data));
-    this._hls.on(Hlsjs.Events.MEDIA_ATTACHED, () => this._hlsMediaAttachedResolver());
+    this._mediaAttachedPromise = new Promise(resolve => (this._onMediaAttached = resolve));
+    this._hls.on(Hlsjs.Events.MEDIA_ATTACHED, () => this._onMediaAttached());
     this._onRecoveredCallback = () => this._onRecovered();
     this._onAddTrack = this._onAddTrack.bind(this);
     this._videoElement.addEventListener('addtrack', this._onAddTrack);

--- a/src/hls-adapter.js
+++ b/src/hls-adapter.js
@@ -105,6 +105,8 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
   _onRecoveredCallback: ?Function;
   _onAddTrack: Function;
   _resolveLoadTimeout: number;
+  _hlsMediaAttachedResolver: Function;
+  _mediaAttachedPromise: Promise<*>;
 
   /**
    * Factory method to create media source adapter.

--- a/yarn.lock
+++ b/yarn.lock
@@ -2162,6 +2162,11 @@ eventemitter3@1.x.x:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-1.2.0.tgz#1c86991d816ad1e504750e73874224ecf3bec508"
 
+eventemitter3@3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-3.1.0.tgz#090b4d6cdbd645ed10bf750d4b5407942d7ba163"
+  integrity sha512-ivIvhpq/Y0uSjcHDcOIccjmYjGLcP09MFGE7ysAwkAvkXfpZlC985pH2/ui64DKazbTW/4kN3yqozUxlXzI6cA==
+
 events@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/events/-/events-1.1.1.tgz#9ebdb7635ad099c70dcc4c2a1f5004288e8bd924"
@@ -2807,12 +2812,13 @@ hawk@~3.1.3:
     hoek "2.x.x"
     sntp "1.x.x"
 
-hls.js@^0.10.1:
-  version "0.10.1"
-  resolved "https://registry.yarnpkg.com/hls.js/-/hls.js-0.10.1.tgz#2675245be1ba83aa023b11b5f5432af62be63330"
+hls.js@^0.12.0:
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/hls.js/-/hls.js-0.12.0.tgz#07ff97dabcf2a892e6fb4b5335d4325a872640dc"
+  integrity sha512-NB1fHxb5bWPc1uBCra/hzoeyWmsokKUWwZVVGrWrqjFyfdG0WCdwEO3RS6eF/4vw0FYdhuHNjVZsj4oD5sYKnA==
   dependencies:
-    string.prototype.endswith "^0.2.0"
-    url-toolkit "^2.1.2"
+    eventemitter3 "3.1.0"
+    url-toolkit "^2.1.6"
 
 hmac-drbg@^1.0.0:
   version "1.0.1"
@@ -5720,9 +5726,10 @@ url-parse@^1.1.1:
     querystringify "~1.0.0"
     requires-port "1.0.x"
 
-url-toolkit@^2.1.2:
-  version "2.1.4"
-  resolved "https://registry.yarnpkg.com/url-toolkit/-/url-toolkit-2.1.4.tgz#e0dac60e5fdd50b8ac984307699e8b72439b3fd3"
+url-toolkit@^2.1.6:
+  version "2.1.6"
+  resolved "https://registry.yarnpkg.com/url-toolkit/-/url-toolkit-2.1.6.tgz#6d03246499e519aad224c44044a4ae20544154f2"
+  integrity sha512-UaZ2+50am4HwrV2crR/JAf63Q4VvPYphe63WGeoJxeu8gmOm0qxPt+KsukfakPNrX9aymGNEkkaoICwn+OuvBw==
 
 url@^0.11.0:
   version "0.11.0"


### PR DESCRIPTION
### Description of the Changes

Listening to hlsjs `MEDIA_ATTACHED` event before selecting a text track. 
Created a promise that will be resolved when this event is triggered.
Only on `promise.resolve()` we will select a text track.

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [x] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
