### PR TITLE
chore(FEC-9054): expose umd named define for requireJS

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -24,6 +24,7 @@ module.exports = {
     filename: '[name].js',
     library: ['playkit', 'hls'],
     libraryTarget: 'umd',
+    umdNamedDefine: true,
     devtoolModuleFilenameTemplate: './hls/[resource-path]'
   },
   devtool: 'source-map',


### PR DESCRIPTION
added umdNamedDefine: true to webpack.config.js to support umd named define for requireJS
