### PR TITLE
fix(FEC-9262): playback doesn't return to start after playback with ads in LG TV

### DIFF
--- a/src/hls-adapter.js
+++ b/src/hls-adapter.js
@@ -307,7 +307,10 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
           this.currentTime = this._lastTimeDetach;
           this._lastTimeDetach = NaN;
         };
-        this._eventManager.listenOnce(this._videoElement, EventType.CAN_PLAY, canPlayHandler);
+        this._eventManager.listenOnce(this._videoElement, EventType.LOADED_DATA, canPlayHandler);
+      } else {
+        this._eventManager.listenOnce(this._videoElement, EventType.PLAY, () => (this.currentTime = 0));
+        this._lastTimeDetach = NaN;
       }
     }
   }

--- a/src/hls-adapter.js
+++ b/src/hls-adapter.js
@@ -292,23 +292,25 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
   /**
    * attach media - return the media source to handle the video tag
    * @public
-   * @param {boolean} playbackEnded playback ended after ads and media
    * @returns {void}
    */
-  attachMediaSource(playbackEnded: boolean): void {
+  attachMediaSource(): void {
     if (!this._hls) {
       if (this._videoElement && this._videoElement.src) {
         Utils.Dom.setAttribute(this._videoElement, 'src', '');
         Utils.Dom.removeAttribute(this._videoElement, 'src');
       }
       this._init();
-      const _seekAfterDetach = seekTo => {
-        this.currentTime = seekTo;
+      const _seekAfterDetach = () => {
+        if (parseInt(this._lastTimeDetach) === parseInt(this.duration)) {
+          this.currentTime = 0;
+        } else {
+          this.currentTime = this._lastTimeDetach;
+        }
         this._lastTimeDetach = NaN;
       };
       if (!isNaN(this._lastTimeDetach)) {
-        const seekTo = playbackEnded ? 0 : this._lastTimeDetach;
-        this._eventManager.listenOnce(this._videoElement, EventType.LOADED_DATA, () => _seekAfterDetach(seekTo));
+        this._eventManager.listenOnce(this._videoElement, EventType.LOADED_DATA, () => _seekAfterDetach());
       }
     }
   }

--- a/src/hls-adapter.js
+++ b/src/hls-adapter.js
@@ -303,11 +303,11 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
       }
       this._init();
       if (!isNaN(this._lastTimeDetach) && !playbackEnded) {
-        const canPlayHandler = () => {
+        const loadedDataHandler = () => {
           this.currentTime = this._lastTimeDetach;
           this._lastTimeDetach = NaN;
         };
-        this._eventManager.listenOnce(this._videoElement, EventType.LOADED_DATA, canPlayHandler);
+        this._eventManager.listenOnce(this._videoElement, EventType.LOADED_DATA, loadedDataHandler);
       } else {
         this._eventManager.listenOnce(this._videoElement, EventType.PLAY, () => (this.currentTime = 0));
         this._lastTimeDetach = NaN;

--- a/src/hls-adapter.js
+++ b/src/hls-adapter.js
@@ -307,7 +307,8 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
         this._lastTimeDetach = NaN;
       };
       if (!isNaN(this._lastTimeDetach)) {
-        this._eventManager.listenOnce(this._videoElement, EventType.LOADED_DATA, () => _seekAfterDetach(playbackEnded ? 0 : this._lastTimeDetach));
+        const seekTo = playbackEnded ? 0 : this._lastTimeDetach;
+        this._eventManager.listenOnce(this._videoElement, EventType.LOADED_DATA, () => _seekAfterDetach(seekTo));
       }
     }
   }

--- a/src/hls-adapter.js
+++ b/src/hls-adapter.js
@@ -295,22 +295,19 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
    * @param {boolean} playbackEnded playback ended after ads and media
    * @returns {void}
    */
-  attachMediaSource(playbackEnded: ?boolean): void {
+  attachMediaSource(playbackEnded: boolean): void {
     if (!this._hls) {
       if (this._videoElement && this._videoElement.src) {
         Utils.Dom.setAttribute(this._videoElement, 'src', '');
         Utils.Dom.removeAttribute(this._videoElement, 'src');
       }
       this._init();
-      if (!isNaN(this._lastTimeDetach) && !playbackEnded) {
-        const loadedDataHandler = () => {
-          this.currentTime = this._lastTimeDetach;
-          this._lastTimeDetach = NaN;
-        };
-        this._eventManager.listenOnce(this._videoElement, EventType.LOADED_DATA, loadedDataHandler);
-      } else {
-        this._eventManager.listenOnce(this._videoElement, EventType.PLAY, () => (this.currentTime = 0));
+      const _seekAfterDetach = seekTo => {
+        this.currentTime = seekTo;
         this._lastTimeDetach = NaN;
+      };
+      if (!isNaN(this._lastTimeDetach)) {
+        this._eventManager.listenOnce(this._videoElement, EventType.LOADED_DATA, () => _seekAfterDetach(playbackEnded ? 0 : this._lastTimeDetach));
       }
     }
   }


### PR DESCRIPTION
### Description of the Changes

Add support for replay after ads finish to return to beginning

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
