### PR TITLE
fix: seek doesn't work before video finished loading

### DIFF
--- a/src/hls-adapter.js
+++ b/src/hls-adapter.js
@@ -335,6 +335,7 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
       }
       this._init();
       const _seekAfterDetach = () => {
+        if (isNaN(this._lastTimeDetach)) return;
         if (parseInt(this._lastTimeDetach) === parseInt(this.duration)) {
           this.currentTime = 0;
         } else {
@@ -344,9 +345,8 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
       };
       if (!isNaN(this._lastTimeDetach)) {
         this._eventManager.listenOnce(this._videoElement, EventType.LOADED_DATA, _seekAfterDetach);
-        this._eventManager.listenOnce(this._videoElement, EventType.SEEKED, () =>
-          this._eventManager.unlisten(this._videoElement, EventType.LOADED_DATA, _seekAfterDetach)
-        );
+        //change to NaN to avoid the seek after detach whenever seeked fired before - SmartTV issue
+        this._eventManager.listenOnce(this._videoElement, EventType.SEEKED, () => (this._lastTimeDetach = NaN));
       }
     }
   }


### PR DESCRIPTION
Solve FEC-9316.
unlisten of loaded_data wasn't always earlier enough.
add check for seeked event occurred and don't seek on loaded_data event

### Description of the Changes

Please add a detailed description of the change, whether it's an enhancement or a bugfix.
If the PR is related to an open issue please link to it.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
