### PR TITLE
fix(FEC-9735): when there is reload attempt on a Network error, no error object is set in the payload

### DIFF
--- a/src/hls-adapter.js
+++ b/src/hls-adapter.js
@@ -942,15 +942,18 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
       let error: typeof Error;
       switch (errorType) {
         case Hlsjs.ErrorTypes.NETWORK_ERROR:
-          if (
-            [Hlsjs.ErrorDetails.MANIFEST_LOAD_ERROR, Hlsjs.ErrorDetails.MANIFEST_LOAD_TIMEOUT].includes(errorName) &&
-            !this._triedReloadWithRedirect &&
-            !this._config.forceRedirectExternalStreams
-          ) {
-            this._reloadWithDirectManifest();
-          } else {
+          {
             const code = this._requestFilterError ? Error.Code.REQUEST_FILTER_ERROR : Error.Code.HTTP_ERROR;
-            error = new Error(Error.Severity.CRITICAL, Error.Category.NETWORK, code, errorDataObject);
+            if (
+              [Hlsjs.ErrorDetails.MANIFEST_LOAD_ERROR, Hlsjs.ErrorDetails.MANIFEST_LOAD_TIMEOUT].includes(errorName) &&
+              !this._triedReloadWithRedirect &&
+              !this._config.forceRedirectExternalStreams
+            ) {
+              error = new Error(Error.Severity.RECOVERABLE, Error.Category.NETWORK, code, errorDataObject);
+              this._reloadWithDirectManifest();
+            } else {
+              error = new Error(Error.Severity.CRITICAL, Error.Category.NETWORK, code, errorDataObject);
+            }
           }
           break;
         case Hlsjs.ErrorTypes.MEDIA_ERROR:


### PR DESCRIPTION
### Description of the Changes

in onError, added error object assignment to be fired also in manifest reload

### CheckLists

- [X] changes have been done against master branch, and PR does not conflict
- [X] new unit / functional tests have been added (whenever applicable)
- [X] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
