### PR TITLE
fix(FEC-10819): selecting 708 captions selects wrong native text track

### DIFF
--- a/src/hls-adapter.js
+++ b/src/hls-adapter.js
@@ -717,7 +717,9 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
    * @private
    */
   _selectNativeTextTrack(textTrack: TextTrack): void {
-    const selectedTrack = Array.from(this._videoElement.textTracks).find(track => track.language === textTrack.language);
+    const selectedTrack = Array.from(this._videoElement.textTracks).find(
+      track => (track.language && track.language === textTrack.language) || track.label === textTrack.label
+    );
     if (selectedTrack) {
       this._disableNativeTextTracks();
       selectedTrack.mode = this._config.subtitleDisplay ? 'showing' : 'hidden';

--- a/src/hls-adapter.js
+++ b/src/hls-adapter.js
@@ -114,7 +114,7 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
   _mediaAttachedPromise: Promise<*>;
   _requestFilterError: boolean = false;
   _responseFilterError: boolean = false;
-
+  _nativeTextTracksMap = [];
   /**
    * Factory method to create media source adapter.
    * @function createAdapter
@@ -545,6 +545,7 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
           HlsAdapter._logger.debug('destroy');
           this._loadPromise = null;
           this._playerTracks = [];
+          this._nativeTextTracksMap = [];
           this._reset();
           resolve();
         },
@@ -664,6 +665,7 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
         index: this._playerTracks.filter(track => track instanceof TextTrack).length
       };
       textTrack = new TextTrack(settings);
+      this._nativeTextTracksMap[settings.index] = CEATextTrack;
     }
     return textTrack;
   }
@@ -723,9 +725,7 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
    * @private
    */
   _selectNativeTextTrack(textTrack: TextTrack): void {
-    const selectedTrack = Array.from(this._videoElement.textTracks).find(
-      track => (track.language && track.language === textTrack.language) || track.label === textTrack.label
-    );
+    const selectedTrack = this._nativeTextTracksMap[textTrack.index];
     if (selectedTrack) {
       this._disableNativeTextTracks();
       selectedTrack.mode = this._config.subtitleDisplay ? 'showing' : 'hidden';


### PR DESCRIPTION
### Description of the Changes

**Issue:** Select text by lang or label is not reliable because they could be the same for more than one track
(e.g. when cc3 and cc4 of 608 are empty - both of them are `UNKNOWN CC` label).
**Solution:** save the native track once added and use it in the selection 
(Selecting by index is not reliable because it's possible there are native tracks from previous playbacks)

Solves FEC-10819

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
