### PR TITLE
feat(FEC-10657): add max stale level reloads config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [1.22.0](https://github.com/kaltura/playkit-js-hls/compare/v1.21.2...v1.22.0) (2021-01-07)
+
+
+### Bug Fixes
+
+* **FEC-10662:** incorrect flow in destroy process ([#123](https://github.com/kaltura/playkit-js-hls/issues/123)) ([ad220f8](https://github.com/kaltura/playkit-js-hls/commit/ad220f8))
+* **FEC-10819:** selecting 708 captions selects wrong native text track ([#126](https://github.com/kaltura/playkit-js-hls/issues/126)) ([44f78c8](https://github.com/kaltura/playkit-js-hls/commit/44f78c8))
+
+
+### Features
+
+* **FEC-10766:** create text config section and option for styling ([#124](https://github.com/kaltura/playkit-js-hls/issues/124)) ([fd12025](https://github.com/kaltura/playkit-js-hls/commit/fd12025))
+
+
+### Tests
+
+* targetBuffer check doesn't perfectly equal and replace invalid stream ([#122](https://github.com/kaltura/playkit-js-hls/issues/122)) ([751c979](https://github.com/kaltura/playkit-js-hls/commit/751c979))
+
+
+
 ### [1.21.2](https://github.com/kaltura/playkit-js-hls/compare/v1.21.1...v1.21.2) (2020-11-03)
 
 

--- a/package.json
+++ b/package.json
@@ -2,21 +2,44 @@
   "name": "@playkit-js/playkit-js-hls",
   "version": "1.22.0",
   "description": "",
+  "keywords": [
+    "hls",
+    "m3u8",
+    "kaltura",
+    "player",
+    "playkit-js",
+    "playkit-js-hls",
+    "html5 player"
+  ],
+  "homepage": "https://github.com/kaltura/playkit-js-hls#readme",
+  "bugs": {
+    "url": "https://github.com/kaltura/playkit-js-hls/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/kaltura/playkit-js-hls.git"
+  },
+  "license": "AGPL-3.0",
   "main": "dist/playkit-hls.js",
   "scripts": {
-    "clean": "rm -rf ./dist",
     "prebuild": "npm run clean",
     "build": "webpack --mode production",
+    "clean": "rm -rf ./dist",
+    "commit:dist": "git add --force --all dist && (git commit -m 'chore: update dist' || exit 0)",
     "dev": "webpack-dev-server --mode development",
-    "watch": "webpack --progress --colors --watch --mode development",
-    "test": "NODE_ENV=test karma start --color --mode development",
-    "release": "standard-version",
-    "pushTaggedRelease": "git push --follow-tags --no-verify origin master",
     "eslint": "eslint . --color",
     "flow": "flow check",
-    "commit:dist": "git add --force --all dist && (git commit -m 'chore: update dist' || exit 0)",
     "precommit": "lint-staged",
-    "prettier:fix": "prettier --write ."
+    "prettier:fix": "prettier --write .",
+    "pushTaggedRelease": "git push --follow-tags --no-verify origin master",
+    "release": "standard-version",
+    "test": "NODE_ENV=test karma start --color --mode development",
+    "watch": "webpack --progress --colors --watch --mode development"
+  },
+  "husky": {
+    "hooks": {
+      "pre-commit": "lint-staged"
+    }
   },
   "lint-staged": {
     "*.{js,jsx}": [
@@ -27,9 +50,6 @@
       "prettier --write",
       "git add"
     ]
-  },
-  "publishConfig": {
-    "access": "public"
   },
   "devDependencies": {
     "@babel/cli": "^7.10.5",
@@ -85,24 +105,9 @@
     "@playkit-js/playkit-js": "0.63.0",
     "hls.js": "0.14.9"
   },
-  "keywords": [
-    "hls",
-    "m3u8",
-    "kaltura",
-    "player",
-    "playkit-js",
-    "playkit-js-hls",
-    "html5 player"
-  ],
-  "license": "AGPL-3.0",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/kaltura/playkit-js-hls.git"
+  "publishConfig": {
+    "access": "public"
   },
-  "bugs": {
-    "url": "https://github.com/kaltura/playkit-js-hls/issues"
-  },
-  "homepage": "https://github.com/kaltura/playkit-js-hls#readme",
   "kcc": {
     "name": "playkit-hls"
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@playkit-js/playkit-js-hls",
-  "version": "1.21.2",
+  "version": "1.22.0",
   "description": "",
   "main": "dist/playkit-hls.js",
   "scripts": {

--- a/src/hls-adapter.js
+++ b/src/hls-adapter.js
@@ -115,6 +115,8 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
   _requestFilterError: boolean = false;
   _responseFilterError: boolean = false;
   _nativeTextTracksMap = [];
+  _lastLoadedFragSN: number = -1;
+  _sameFragSNLoadedCount: number = 0;
   /**
    * Factory method to create media source adapter.
    * @function createAdapter
@@ -239,6 +241,7 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
     this._config = Utils.Object.mergeDeep({}, DefaultConfig, this._config);
     this._init();
   }
+
   /**
    * init the hls adapter
    * @function _init
@@ -404,6 +407,9 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
     this._onAddTrack = this._onAddTrack.bind(this);
     this._eventManager.listen(this._videoElement, 'addtrack', this._onAddTrack);
     this._videoElement.textTracks.onaddtrack = this._onAddTrack;
+    if (this.isLive()) {
+      this._hls.on(Hlsjs.Events.LEVEL_LOADED, this._onLevelLoaded);
+    }
   }
 
   _onFpsDrop(data: Object): void {
@@ -425,6 +431,7 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
       }
     }
   }
+
   /**
    * attach media - return the media source to handle the video tag
    * @public
@@ -453,6 +460,7 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
       }
     }
   }
+
   /**
    * detach media - will remove the media source from handling the video
    * @public
@@ -466,6 +474,7 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
       this._hls = null;
     }
   }
+
   /**
    * video error event handler.
    * @param {MediaError} error - the media error
@@ -548,6 +557,8 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
           this._loadPromise = null;
           this._playerTracks = [];
           this._nativeTextTracksMap = [];
+          this._sameFragSNLoadedCount = 0;
+          this._lastLoadedFragSN = -1;
           this._reset();
           resolve();
         },
@@ -854,7 +865,8 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
     try {
       return !!this._getLevelDetails().live;
     } catch (e) {
-      return false;
+      // return false;
+      return true;
     }
   }
 
@@ -1080,7 +1092,10 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
     } else {
       const {category, code}: ErrorDetailsType =
         this._requestFilterError || this._responseFilterError
-          ? {category: Error.Category.NETWORK, code: this._requestFilterError ? Error.Code.REQUEST_FILTER_ERROR : Error.Code.RESPONSE_FILTER_ERROR}
+          ? {
+              category: Error.Category.NETWORK,
+              code: this._requestFilterError ? Error.Code.REQUEST_FILTER_ERROR : Error.Code.RESPONSE_FILTER_ERROR
+            }
           : HlsJsErrorMap[errorName] || {category: 0, code: 0};
       HlsAdapter._logger.warn(new Error(Error.Severity.RECOVERABLE, category, code, errorDataObject));
     }
@@ -1204,6 +1219,36 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
   }
 
   /**
+   * called when a level is loaded
+   * @private
+   * @param {any} e - the event object
+   * @param {any} data - the event data
+   * @returns {void}
+   */
+  _onLevelLoaded = (e: any, data: any) => {
+    const {
+      details: {endSN}
+    } = data;
+    if (this._lastLoadedFragSN === endSN) {
+      this._sameFragSNLoadedCount++;
+      HlsAdapter._logger.debug(`Same frag SN. Count is: ${this._sameFragSNLoadedCount}, Max is: ${this._config.network.maxStaleLevelReloads}`);
+      if (this._sameFragSNLoadedCount >= this._config.network.maxStaleLevelReloads) {
+        HlsAdapter._logger.error(`Same frag loading reached max count`);
+        const error = new Error(Error.Severity.CRITICAL, Error.Category.NETWORK, Error.Code.LIVE_MANIFEST_REFRESH_ERROR, {
+          fragSN: endSN
+        });
+        this._trigger(EventType.ERROR, error);
+        return this.destroy();
+      }
+    } else {
+      HlsAdapter._logger.debug(`Different frag SN is loaded. Reset count`);
+      this._sameFragSNLoadedCount = 0;
+    }
+    HlsAdapter._logger.debug(`Last frag SN is: ${endSN}`);
+    this._lastLoadedFragSN = endSN;
+  };
+
+  /**
    * called when a fragment is loaded
    * @private
    * @param {any} data - the event data of the loaded fragment
@@ -1211,7 +1256,11 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
    */
   _onFragLoaded(data: any): void {
     const fragmentDownloadTime = data.stats.tload - data.stats.trequest;
-    this._trigger(EventType.FRAG_LOADED, {miliSeconds: fragmentDownloadTime, bytes: data.stats.loaded, url: data.frag.url});
+    this._trigger(EventType.FRAG_LOADED, {
+      miliSeconds: fragmentDownloadTime,
+      bytes: data.stats.loaded,
+      url: data.frag.url
+    });
   }
 
   /**

--- a/src/hls-adapter.js
+++ b/src/hls-adapter.js
@@ -865,8 +865,7 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
     try {
       return !!this._getLevelDetails().live;
     } catch (e) {
-      // return false;
-      return true;
+      return false;
     }
   }
 


### PR DESCRIPTION
### Description of the Changes

If a live manifest is refreshed more than a preconfigured amount of times without any new segment,  raise a critical error and stop playback.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
