### PR TITLE
feat(FEC-10686): move startTime config from playback to sources

### DIFF
--- a/src/hls-adapter.js
+++ b/src/hls-adapter.js
@@ -134,10 +134,10 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
       pLoader.redirectExternalStreamsHandler = adapterConfig.redirectExternalStreamsHandler;
       pLoader.redirectExternalStreamsTimeout = adapterConfig.redirectExternalStreamsTimeout;
     }
-    if (Utils.Object.hasPropertyPath(config, 'playback.startTime')) {
-      const startTime = Utils.Object.getPropertyPath(config, 'playback.startTime');
+    if (Utils.Object.hasPropertyPath(config, 'sources.startTime')) {
+      const startTime = Utils.Object.getPropertyPath(config, 'sources.startTime');
       if (startTime > -1) {
-        adapterConfig.hlsConfig.startPosition = config.playback.startTime;
+        adapterConfig.hlsConfig.startPosition = config.sources.startTime;
       }
     }
     if (Utils.Object.hasPropertyPath(config, 'text.useNativeTextTrack')) {


### PR DESCRIPTION
### Description of the Changes

move startTime to the sources config so it will take place only on the a specific source.



### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
