### PR TITLE
fix(FEC-10657): move isLive check for LEVEL_LOADED event

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "@babel/preset-env": "^7.10.4",
     "@babel/preset-flow": "^7.10.4",
     "@babel/register": "^7.10.5",
-    "@playkit-js/playkit-js": "0.63.0",
+    "@playkit-js/playkit-js": "0.67.0-canary.8d385c8",
     "babel-eslint": "^10.1.0",
     "babel-loader": "^8.1.0",
     "babel-plugin-istanbul": "^6.0.0",
@@ -102,7 +102,7 @@
     "webpack-dev-server": "^3.11.0"
   },
   "peerDependencies": {
-    "@playkit-js/playkit-js": "0.63.0",
+    "@playkit-js/playkit-js": "0.67.0-canary.8d385c8",
     "hls.js": "0.14.9"
   },
   "publishConfig": {

--- a/src/hls-adapter.js
+++ b/src/hls-adapter.js
@@ -401,13 +401,13 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
     this._hls.on(Hlsjs.Events.FPS_DROP, (e, data) => this._onFpsDrop(data));
     this._hls.on(Hlsjs.Events.FRAG_PARSING_METADATA, (e, data) => this._onFragParsingMetadata(data));
     this._hls.on(Hlsjs.Events.FRAG_LOADED, (e, data) => this._onFragLoaded(data));
+    this._hls.on(Hlsjs.Events.LEVEL_LOADED, this._onLevelLoaded);
     this._mediaAttachedPromise = new Promise(resolve => (this._onMediaAttached = resolve));
     this._hls.on(Hlsjs.Events.MEDIA_ATTACHED, () => this._onMediaAttached());
     this._onRecoveredCallback = () => this._onRecovered();
     this._onAddTrack = this._onAddTrack.bind(this);
     this._eventManager.listen(this._videoElement, 'addtrack', this._onAddTrack);
     this._videoElement.textTracks.onaddtrack = this._onAddTrack;
-    this._hls.on(Hlsjs.Events.LEVEL_LOADED, this._onLevelLoaded);
   }
 
   _onFpsDrop(data: Object): void {

--- a/src/hls-adapter.js
+++ b/src/hls-adapter.js
@@ -407,9 +407,7 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
     this._onAddTrack = this._onAddTrack.bind(this);
     this._eventManager.listen(this._videoElement, 'addtrack', this._onAddTrack);
     this._videoElement.textTracks.onaddtrack = this._onAddTrack;
-    if (this.isLive()) {
-      this._hls.on(Hlsjs.Events.LEVEL_LOADED, this._onLevelLoaded);
-    }
+    this._hls.on(Hlsjs.Events.LEVEL_LOADED, this._onLevelLoaded);
   }
 
   _onFpsDrop(data: Object): void {
@@ -1225,25 +1223,27 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
    * @returns {void}
    */
   _onLevelLoaded = (e: any, data: any) => {
-    const {
-      details: {endSN}
-    } = data;
-    if (this._lastLoadedFragSN === endSN) {
-      this._sameFragSNLoadedCount++;
-      HlsAdapter._logger.debug(`Same frag SN. Count is: ${this._sameFragSNLoadedCount}, Max is: ${this._config.network.maxStaleLevelReloads}`);
-      if (this._sameFragSNLoadedCount >= this._config.network.maxStaleLevelReloads) {
-        HlsAdapter._logger.error(`Same frag loading reached max count`);
-        const error = new Error(Error.Severity.CRITICAL, Error.Category.NETWORK, Error.Code.LIVE_MANIFEST_REFRESH_ERROR, {
-          fragSN: endSN
-        });
-        this._trigger(EventType.ERROR, error);
-        return this.destroy();
+    if (this.isLive()) {
+      const {
+        details: {endSN}
+      } = data;
+      if (this._lastLoadedFragSN === endSN) {
+        this._sameFragSNLoadedCount++;
+        HlsAdapter._logger.debug(`Same frag SN. Count is: ${this._sameFragSNLoadedCount}, Max is: ${this._config.network.maxStaleLevelReloads}`);
+        if (this._sameFragSNLoadedCount >= this._config.network.maxStaleLevelReloads) {
+          HlsAdapter._logger.error(`Same frag loading reached max count`);
+          const error = new Error(Error.Severity.CRITICAL, Error.Category.NETWORK, Error.Code.LIVE_MANIFEST_REFRESH_ERROR, {
+            fragSN: endSN
+          });
+          this._trigger(EventType.ERROR, error);
+          return this.destroy();
+        }
+        HlsAdapter._logger.debug(`Last frag SN is: ${endSN}`);
+      } else {
+        this._sameFragSNLoadedCount = 0;
       }
-      HlsAdapter._logger.debug(`Last frag SN is: ${endSN}`);
-    } else {
-      this._sameFragSNLoadedCount = 0;
+      this._lastLoadedFragSN = endSN;
     }
-    this._lastLoadedFragSN = endSN;
   };
 
   /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -853,10 +853,10 @@
   resolved "https://registry.yarnpkg.com/@istanbuljs/schema/-/schema-0.1.2.tgz#26520bf09abe4a5644cd5414e37125a8954241dd"
   integrity sha512-tsAQNx32a8CoFhjhijUIhI4kccIAgmGhy8LZMZgGfmXcpMbPRUqn5LWmgRttILi6yeGmBJd2xsPkFMs0PzgPCw==
 
-"@playkit-js/playkit-js@0.63.0":
-  version "0.63.0"
-  resolved "https://registry.yarnpkg.com/@playkit-js/playkit-js/-/playkit-js-0.63.0.tgz#01c073dc2067befe57cdca168ea54b8583e07a30"
-  integrity sha512-nJejwY2HQGk/imgqtkma79KOII4F2LIYm5E2irUJHv/8luflCuBwsihX/jD1H+kdkXvB5GjT9v2LHHHbfcj6Sg==
+"@playkit-js/playkit-js@0.67.0-canary.8d385c8":
+  version "0.67.0-canary.8d385c8"
+  resolved "https://registry.yarnpkg.com/@playkit-js/playkit-js/-/playkit-js-0.67.0-canary.8d385c8.tgz#8e4e56f81a8a84149362713d08bf86935ca2953b"
+  integrity sha512-3wy00sLLE2QtysQ6FAK5AL0VWaxOd+KAiXPSMR0sYyf1uUKRv5BoZKEN1J0AXWSNzxDNG8UFPVr6rIUIdt+N5Q==
   dependencies:
     js-logger "^1.6.0"
     ua-parser-js "^0.7.21"


### PR DESCRIPTION
### Description of the Changes

The check for `isLive()` in `addBindings` is too early - no frags are loaded in that point, so `isLive()` always returns `false`.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
