### PR TITLE
feat(FEC-11091): add support for XMLHttpRequest.withCredentials in request filter 

### DIFF
--- a/src/hls-adapter.js
+++ b/src/hls-adapter.js
@@ -296,6 +296,9 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
               Object.entries(updatedRequest.headers).forEach(entry => {
                 xhr.setRequestHeader(...entry);
               });
+              if (typeof updatedRequest.withCredentials === 'boolean') {
+                xhr.withCredentials = updatedRequest.withCredentials;
+              }
             })
             .catch(error => {
               this._requestFilterError = true;


### PR DESCRIPTION
### Description of the Changes

Support `withCredentials` on updated request.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
