### PR TITLE
fix(FEC-11126): if set abr.enabled=false, auto mode still remains enabled - HLS

### DIFF
--- a/src/hls-adapter.js
+++ b/src/hls-adapter.js
@@ -897,6 +897,10 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
       this._hls.startLoad(this._startTime);
     }
     this._playerTracks = this._parseTracks();
+    // set current level to disable the auto selection in hls
+    if (!this._config.abr.enabled) {
+      this._hls.currentLevel = 0;
+    }
     this._mediaAttachedPromise.then(() => {
       this._resolveLoad({tracks: this._playerTracks});
     });


### PR DESCRIPTION
### Description of the Changes

Issue: ABR disable doesn't select on the first.
Solution: change the internal state of HLS.JS to disable the auto selection.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
