### PR TITLE
fix(FEC-11800): captions taking longer to load

### DIFF
--- a/src/hls-adapter.js
+++ b/src/hls-adapter.js
@@ -119,7 +119,7 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
   _onAddTrack: Function;
   _onMediaAttached: Function;
   _mediaAttachedPromise: Promise<*>;
-  _onSubtitleTrackLoaded: Function;
+  _onSubtitleFragProcessed: Function;
   _subtitleTrackInitializedPromise: Promise<*>;
   _requestFilterError: boolean = false;
   _responseFilterError: boolean = false;
@@ -143,7 +143,7 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
     [Hlsjs.Events.FRAG_LOADED]: (e, data) => this._onFragLoaded(data),
     [Hlsjs.Events.MEDIA_ATTACHED]: () => this._onMediaAttached(),
     [Hlsjs.Events.LEVEL_LOADED]: (e, data) => this._onLevelLoaded(e, data),
-    [Hlsjs.Events.SUBTITLE_TRACK_LOADED]: (e, data) => this._onSubtitleTrackLoaded(e, data)
+    [Hlsjs.Events.SUBTITLE_FRAG_PROCESSED]: (e, data) => this._onSubtitleFragProcessed(e, data)
   };
 
   /**
@@ -421,9 +421,9 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
   _addBindings(): void {
     this._mediaAttachedPromise = new Promise(resolve => (this._onMediaAttached = resolve));
     this._subtitleTrackInitializedPromise = new Promise(resolve => {
-      this._onSubtitleTrackLoaded = () => {
+      this._onSubtitleFragProcessed = () => {
         resolve();
-        this._hls.off(Hlsjs.Events.SUBTITLE_TRACK_LOADED, this._adapterEventsBindings[Hlsjs.Events.SUBTITLE_TRACK_LOADED]);
+        this._hls.off(Hlsjs.Events.SUBTITLE_FRAG_PROCESSED, this._adapterEventsBindings[Hlsjs.Events.SUBTITLE_FRAG_PROCESSED]);
       };
     });
 


### PR DESCRIPTION
### Description of the Changes

**the issue:**
When starting video with captions "off" and then switching to the default captions -> it takes ~10 sec to load.
similar issue was found here- FEC-11585 and was fixed, however still not solving our issue- the only difference is that in FEC-11585 the vtt file is downloaded in one file, while in our case, vtt are coming in separated fragments.

**solution:**
using hlsjs event "SUBTITLE_FRAG_PROCESSED" instead of "SUBTITLE_TRACK_LOADED".

solves FEC-11800

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
