### PR TITLE
fix(FEC-11760): Live captioning with Virtuvent not updating captions

### DIFF
--- a/src/custom-timeline-controller.js
+++ b/src/custom-timeline-controller.js
@@ -1,0 +1,26 @@
+//@flow
+import Hlsjs from 'hls.js';
+
+class CustomTimelineController extends Hlsjs.DefaultConfig.timelineController {
+  constructor(hls: Hlsjs) {
+    super(hls);
+
+    if (this.cea608Parser1 && this.cea608Parser2) {
+      const originalResetParser = this.cea608Parser1.reset;
+      this.cea608Parser1.reset = resetParser.bind(this.cea608Parser1, originalResetParser);
+      this.cea608Parser2.reset = resetParser.bind(this.cea608Parser2, originalResetParser);
+    }
+  }
+}
+
+// eslint-disable-next-line require-jsdoc
+function resetParser(originalResetParser) {
+  for (const channel of this.channels) {
+    if (channel) {
+      channel.outputFilter.startTime = null;
+    }
+  }
+  originalResetParser.apply(this);
+}
+
+export default CustomTimelineController;

--- a/src/hls-adapter.js
+++ b/src/hls-adapter.js
@@ -18,6 +18,7 @@ import {
 } from '@playkit-js/playkit-js';
 import pLoader from './jsonp-ploader';
 import loader from './loader';
+import CustomTimelineController from './custom-timeline-controller';
 
 /**
  * Adapter of hls.js lib for hls content.
@@ -126,7 +127,6 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
   _nativeTextTracksMap = [];
   _lastLoadedFragSN: number = -1;
   _sameFragSNLoadedCount: number = 0;
-  _textTrackIndex = -1;
   /**
    * an object containing all the events we bind and unbind to.
    * @member {Object} - _adapterEventsBindings
@@ -274,6 +274,7 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
       this._config.hlsConfig['pLoader'] = pLoader;
     }
     this._maybeSetFilters();
+    this._config.hlsConfig.timelineController = CustomTimelineController;
     this._hls = new Hlsjs(this._config.hlsConfig);
     this._capabilities.fpsControl = true;
     this._hls.subtitleDisplay = this._config.subtitleDisplay;
@@ -433,7 +434,6 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
     this._onRecoveredCallback = () => this._onRecovered();
     this._onAddTrack = this._onAddTrack.bind(this);
     this._eventManager.listen(this._videoElement, 'addtrack', this._onAddTrack);
-    this._eventManager.listen(this._videoElement, 'seeked', this._onSeeked.bind(this));
     this._videoElement.textTracks.onaddtrack = this._onAddTrack;
   }
 
@@ -453,22 +453,6 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
         HlsAdapter._logger.debug('A CEA 608/708 caption has been found', CEATextTrack);
         this._playerTracks.push(CEATextTrack);
         this._trigger(EventType.TRACKS_CHANGED, {tracks: this._playerTracks});
-      }
-    }
-  }
-
-  _onSeeked() {
-    const textTrack = this._nativeTextTracksMap[this._textTrackIndex];
-    if (textTrack) {
-      // workaround to clear CEA 608 cues which have an incorrect startTime after seek forward
-      const cues = textTrack.cues;
-      if (cues && cues.length > 1) {
-        for (let i = 0; i < cues.length - 1; ++i) {
-          if (Math.floor(cues[i].endTime) > Math.floor(cues[i + 1].endTime)) {
-            textTrack.removeCue(cues[i]);
-            break;
-          }
-        }
       }
     }
   }
@@ -591,7 +575,6 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
           this._nativeTextTracksMap = [];
           this._sameFragSNLoadedCount = 0;
           this._lastLoadedFragSN = -1;
-          this._textTrackIndex = -1;
           this._reset();
           resolve();
         },
@@ -780,7 +763,6 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
   }
 
   _notifyTrackChanged(textTrack: TextTrack): void {
-    this._textTrackIndex = textTrack.index;
     this._onTrackChanged(textTrack);
   }
 


### PR DESCRIPTION
### Description of the Changes

Previous solution depends on seek event handler and on the problematic cue not being the last cue.
A more thorough solution is using custom timeline controller to clear cue start time on every reset of the parser.
Since we don't have access to the parser itself we override its reset function in timeline controller constructor.

Fixes FEC-11760.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
