### PR TITLE
fix(FEC-12460): upgrade HLS.JS player to v1.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     ]
   },
   "devDependencies": {
+    "hls.js": "^1.2.0",
     "@babel/cli": "^7.10.5",
     "@babel/core": "^7.10.5",
     "@babel/plugin-proposal-class-properties": "^7.10.4",
@@ -75,7 +76,6 @@
     "eslint-plugin-mocha-no-only": "^1.1.0",
     "eslint-plugin-prettier": "^3.1.4",
     "flow-bin": "^0.129.0",
-    "hls.js": "^1.1.5",
     "husky": "^4.2.5",
     "istanbul": "^0.4.5",
     "karma": "^5.1.0",
@@ -104,7 +104,7 @@
   },
   "peerDependencies": {
     "@playkit-js/playkit-js": "canary",
-    "hls.js": "^1.1.5"
+    "hls.js": "^1.2.0"
   },
   "publishConfig": {
     "access": "public"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4140,10 +4140,10 @@ he@1.2.0:
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
 
-hls.js@^1.1.5:
-  version "1.1.5"
-  resolved "https://registry.yarnpkg.com/hls.js/-/hls.js-1.1.5.tgz#923a8a8cfdf09542578696d47c8ae435da981ffd"
-  integrity sha512-mQX5TSNtJEzGo5HPpvcQgCu+BWoKDQM6YYtg/KbgWkmVAcqOCvSTi0SuqG2ZJLXxIzdnFcKU2z7Mrw/YQWhPOA==
+hls.js@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/hls.js/-/hls.js-1.2.0.tgz#e213773be09d6f99f08cefbf608c4a1fe226f998"
+  integrity sha512-QIEQIUpBRhcpBMq3NA+/qozG8lbNfVekuX7kCMUlhiVu4382xFWsnwcuBe/CA4Gp/wB/pf2aRBaGRFlxh/FN8g==
 
 hmac-drbg@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
### Description of the Changes

upgrade HLS.JS player to v1.2.0

solves:  FEC-12460

related pr: https://github.com/kaltura/kaltura-player-js/pull/560

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
