### PR TITLE
fix(FEC-12527): turning on hls debug mode in config causes the player to crash

### DIFF
--- a/src/hls-adapter.js
+++ b/src/hls-adapter.js
@@ -112,7 +112,7 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
    * @type {Array<Track>}
    * @private
    */
-  _playerTracks: Array<Track>;
+  _playerTracks: Array<Track> = [];
   /**
    * stream start time in seconds
    * @type {?number}
@@ -282,6 +282,14 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
     if (this._config.forceRedirectExternalStreams) {
       this._config.hlsConfig['pLoader'] = pLoader;
     }
+    //this._config.hlsConfig.debug = true;
+    //this._config.hlsConfig.autoStartLoad = false;
+    //this._config.hlsConfig.lowLatencyMode = true;
+    //this._config.hlsConfig.liveSyncDurationCount = 20;
+    //this._config.hlsConfig.liveDurationInfinity = true;
+    this._config.hlsConfig.startLevel = 0;
+    this._config.hlsConfig.startFragPrefetch = true;
+
     this._maybeSetFilters();
     this._hls = new Hlsjs(this._config.hlsConfig);
     this._capabilities.fpsControl = true;

--- a/src/hls-adapter.js
+++ b/src/hls-adapter.js
@@ -282,14 +282,6 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
     if (this._config.forceRedirectExternalStreams) {
       this._config.hlsConfig['pLoader'] = pLoader;
     }
-    //this._config.hlsConfig.debug = true;
-    //this._config.hlsConfig.autoStartLoad = false;
-    //this._config.hlsConfig.lowLatencyMode = true;
-    //this._config.hlsConfig.liveSyncDurationCount = 20;
-    //this._config.hlsConfig.liveDurationInfinity = true;
-    this._config.hlsConfig.startLevel = 0;
-    this._config.hlsConfig.startFragPrefetch = true;
-
     this._maybeSetFilters();
     this._hls = new Hlsjs(this._config.hlsConfig);
     this._capabilities.fpsControl = true;


### PR DESCRIPTION
### Description of the Changes

In some cases hls.js triggers our event handlers (specifically _onAudioTrackSwitched) before the _onManifestLoaded handler. When _onAudioTracksSwitched calls _playerTracks.find, which is undefined, it crashes. 
The solution is to initialize _playerTracks with an empty array before _onManifestLoaded fills it with the real values.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
