### PR TITLE
fix(FEC-13010): exclude Hlsjs.ErrorDetails.MANIFEST_INCOMPATIBLE_CODECS_ERROR 

### DIFF
--- a/src/hls-adapter.js
+++ b/src/hls-adapter.js
@@ -523,7 +523,7 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
         'The video playback was aborted due to a corruption problem or because the video used features your browser did not support.',
         error.message
       );
-      return this._handleMediaError();
+      return this._handleMediaError(Hlsjs.ErrorDetails.MANIFEST_INCOMPATIBLE_CODECS_ERROR);
     } else {
       return false;
     }
@@ -1134,7 +1134,7 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
           }
           break;
         case Hlsjs.ErrorTypes.MEDIA_ERROR:
-          if (this._handleMediaError()) {
+          if (this._handleMediaError(errorName)) {
             error = new PKError(PKError.Severity.RECOVERABLE, PKError.Category.MEDIA, PKError.Code.HLS_FATAL_MEDIA_ERROR, errorDataObject);
           } else {
             error = new PKError(PKError.Severity.CRITICAL, PKError.Category.MEDIA, PKError.Code.HLS_FATAL_MEDIA_ERROR, errorDataObject);
@@ -1169,22 +1169,28 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
 
   /**
    * Tries to handle media errors via hls.js error handlers
+   * @param {string} mediaErrorName - Media Error Name
    * @returns {boolean} - if media error is handled or not
    * @private
    */
-  _handleMediaError(): boolean {
+  _handleMediaError(mediaErrorName: string): boolean {
     const now: number = performance.now();
     let recover = true;
-    if (this._checkTimeDeltaHasPassed(now, this._recoverDecodingErrorDate, this._config.recoverDecodingErrorDelay)) {
+    if (mediaErrorName === Hlsjs.ErrorDetails.MANIFEST_INCOMPATIBLE_CODECS_ERROR) {
+      HlsAdapter._logger.error('cannot recover, MANIFEST_INCOMPATIBLE_CODECS_ERROR');
+      recover = false;
+    } else if (this._checkTimeDeltaHasPassed(now, this._recoverDecodingErrorDate, this._config.recoverDecodingErrorDelay)) {
       this._eventManager.listen(this._videoElement, EventType.LOADED_METADATA, this._onRecoveredCallback);
+      HlsAdapter._logger.debug('trying to recoverDecodingError error: ', mediaErrorName);
       this._recoverDecodingError();
     } else {
       if (this._checkTimeDeltaHasPassed(now, this._recoverSwapAudioCodecDate, this._config.recoverSwapAudioCodecDelay)) {
         this._eventManager.listen(this._videoElement, EventType.LOADED_METADATA, this._onRecoveredCallback);
+        HlsAdapter._logger.debug('trying to recoverSwapAudioCodec error: ', mediaErrorName);
         this._recoverSwapAudioCodec();
       } else {
+        HlsAdapter._logger.error('cannot recover, last media error recovery failed error: ', mediaErrorName);
         recover = false;
-        HlsAdapter._logger.error('cannot recover, last media error recovery failed');
       }
     }
     return recover;
@@ -1201,7 +1207,7 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
   }
 
   /**
-   * Check if time ahs passed a certain delta
+   * Check if time has passed a certain delta
    * @param {number} now - current time
    * @param {number} then - previous time
    * @param {number} delay - time delta in ms

--- a/src/hls-adapter.js
+++ b/src/hls-adapter.js
@@ -1174,19 +1174,20 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
    * @private
    */
   _handleMediaError(mediaErrorName: string): boolean {
+    HlsAdapter._logger.error('_handleMediaError mediaErrorName:', mediaErrorName);
     const now: number = performance.now();
     let recover = true;
     if (mediaErrorName === Hlsjs.ErrorDetails.MANIFEST_INCOMPATIBLE_CODECS_ERROR) {
-      HlsAdapter._logger.error('cannot recover, MANIFEST_INCOMPATIBLE_CODECS_ERROR');
+      HlsAdapter._logger.error('recover aborted due to: MANIFEST_INCOMPATIBLE_CODECS_ERROR');
       recover = false;
     } else if (this._checkTimeDeltaHasPassed(now, this._recoverDecodingErrorDate, this._config.recoverDecodingErrorDelay)) {
       this._eventManager.listen(this._videoElement, EventType.LOADED_METADATA, this._onRecoveredCallback);
-      HlsAdapter._logger.debug('trying to recoverDecodingError error: ', mediaErrorName);
+      HlsAdapter._logger.debug('try to recover using: _recoverDecodingError()');
       this._recoverDecodingError();
     } else {
       if (this._checkTimeDeltaHasPassed(now, this._recoverSwapAudioCodecDate, this._config.recoverSwapAudioCodecDelay)) {
         this._eventManager.listen(this._videoElement, EventType.LOADED_METADATA, this._onRecoveredCallback);
-        HlsAdapter._logger.debug('trying to recoverSwapAudioCodec error: ', mediaErrorName);
+        HlsAdapter._logger.debug('try to recover using: _recoverSwapAudioCodec()');
         this._recoverSwapAudioCodec();
       } else {
         HlsAdapter._logger.error('cannot recover, last media error recovery failed error: ', mediaErrorName);


### PR DESCRIPTION
fix prevents recover retry logic to run forever in hls.js for codec errors

FEC-13010

### Description of the Changes

Please add a detailed description of the change, whether it's an enhancement or a bugfix.
If the PR is related to an open issue please link to it.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
