### PR TITLE
fix(FEC-13212): upgrade hls.js to 1.4.11

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -14,7 +14,7 @@
         "bugfixes": true,
         "include": ["@babel/plugin-proposal-optional-chaining"],
         "targets": {
-          "browsers": ["chrome >= 47", "firefox >= 51", "ie >= 11", "safari >= 8", "ios >= 8", "android >= 4"]
+          "browsers": ["defaults"]
         }
       }
     ],

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "eslint-plugin-mocha-no-only": "^1.1.0",
     "eslint-plugin-prettier": "^3.1.4",
     "flow-bin": "^0.129.0",
-    "hls.js": "1.4.10",
+    "hls.js": "1.4.11",
     "husky": "^4.2.5",
     "istanbul": "^0.4.5",
     "karma": "^5.1.0",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "eslint-plugin-mocha-no-only": "^1.1.0",
     "eslint-plugin-prettier": "^3.1.4",
     "flow-bin": "^0.129.0",
-    "hls.js": "1.3.5",
+    "hls.js": "1.4.10",
     "husky": "^4.2.5",
     "istanbul": "^0.4.5",
     "karma": "^5.1.0",

--- a/test/src/hls-adapter.spec.js
+++ b/test/src/hls-adapter.spec.js
@@ -970,10 +970,10 @@ describe('HlsAdapter Instance: response filter', () => {
         }
       })
     );
-    sandbox.spy(hlsAdapterInstance._hls.networkControllers[0], 'loadsuccess');
+    sandbox.spy(hlsAdapterInstance._hls.networkControllers[0], 'handleMasterPlaylist');
     hlsAdapterInstance._hls.on(hlsAdapterInstance._hlsjsLib.Events.MANIFEST_LOADED, () => {
       try {
-        hlsAdapterInstance._hls.networkControllers[0].loadsuccess.getCall(0).firstArg.data.indexOf('&test').should.be.gt(-1);
+        hlsAdapterInstance._hls.networkControllers[0].handleMasterPlaylist.getCall(0).firstArg.data.indexOf('&test').should.be.gt(-1);
         done();
       } catch (e) {
         done(e);
@@ -997,7 +997,7 @@ describe('HlsAdapter Instance: response filter', () => {
         }
       })
     );
-    sandbox.stub(hlsAdapterInstance._hls.networkControllers[0], 'loadsuccess').callsFake(value => {
+    sandbox.stub(hlsAdapterInstance._hls.networkControllers[0], 'handleMasterPlaylist').callsFake(value => {
       try {
         value.data.indexOf('&test').should.be.gt(-1);
         done();

--- a/yarn.lock
+++ b/yarn.lock
@@ -4578,10 +4578,10 @@ he@1.2.0:
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
 
-hls.js@1.4.10:
-  version "1.4.10"
-  resolved "https://registry.yarnpkg.com/hls.js/-/hls.js-1.4.10.tgz#3feac40f21a558453b243b5b926b7317e70624e1"
-  integrity sha512-wAVSj4Fm2MqOHy5+BlYnlKxXvJlv5IuZHjlzHu18QmjRzSDFQiUDWdHs5+NsFMQrgKEBwuWDcyvaMC9dUzJ5Uw==
+hls.js@1.4.11:
+  version "1.4.11"
+  resolved "https://registry.yarnpkg.com/hls.js/-/hls.js-1.4.11.tgz#6ca2d7ab56f2725f27bb5f2e3c7982c6ec287118"
+  integrity sha512-rhPSUMACcIBbcUnwWnIcRgGXqJJt0xBRxvhzl99XpGHtnnLKjbczmmBmUuQueAQcbL3SdN7D5peAObR18VrhvQ==
 
 hmac-drbg@^1.0.0:
   version "1.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4578,10 +4578,10 @@ he@1.2.0:
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
 
-hls.js@1.3.5:
-  version "1.3.5"
-  resolved "https://registry.yarnpkg.com/hls.js/-/hls.js-1.3.5.tgz#0e8b0799ecf2feb7ba199f5e95f35ba9552e04f4"
-  integrity sha512-uybAvKS6uDe0MnWNEPnO0krWVr+8m2R0hJ/viql8H3MVK+itq8gGQuIYoFHL3rECkIpNH98Lw8YuuWMKZxp3Ew==
+hls.js@1.4.10:
+  version "1.4.10"
+  resolved "https://registry.yarnpkg.com/hls.js/-/hls.js-1.4.10.tgz#3feac40f21a558453b243b5b926b7317e70624e1"
+  integrity sha512-wAVSj4Fm2MqOHy5+BlYnlKxXvJlv5IuZHjlzHu18QmjRzSDFQiUDWdHs5+NsFMQrgKEBwuWDcyvaMC9dUzJ5Uw==
 
 hmac-drbg@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
### Description of the Changes

Upgrade hls.js to 1.4.11

Related PR: https://github.com/kaltura/kaltura-player-js/pull/649

Resolves FEC-13212
Resolves [FEC-13322](https://kaltura.atlassian.net/browse/FEC-13322)

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated


[FEC-13322]: https://kaltura.atlassian.net/browse/FEC-13322?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ