### PR TITLE
fix(SUP-39292): V7 Player v3.15.2 Shows ReferenceError

### DIFF
--- a/src/default-config.json
+++ b/src/default-config.json
@@ -7,7 +7,8 @@
   },
   "hlsConfig": {
     "fragLoadingMaxRetry": 4,
-    "maxMaxBufferLength": 60
+    "maxMaxBufferLength": 60,
+    "enableWorker": false
   },
   "network": {}
 }


### PR DESCRIPTION
### Description of the Changes

**Issue**:
Console logs show the message "[Error] Category: 0 | Code: 0 | {name: internalException}" and in some cases also "ReferenceError: e is not defined"

**Explanation**:
hls.js uses a worker thread when decoding video messages
if the worker thread encounters an error, it will fallback to decoding on the main thread and will show the message "warn] > Error in "main" Web Worker, fallback to inline" (visible when playback.options.html5.hls.debug = true)

One of the changes included in the last hls.js version upgrade seems to have been a change in the worker-related code (possibly [this one](https://github.com/video-dev/hls.js/pull/5270))
The hls.js version with these changes works fine when running the player locally, where webpack-dev-server runs with "--mode development"
However, once we build a version and use "--mode production", webpack optimization removes some code from the worker function (i did a text comparison of the worker runtime code and the production version has fewer lines of code), which then causes the worker to throw an error during initialization

This is similar to what is described [in this issue](https://github.com/video-dev/hls.js/issues/5617#issuecomment-1618970498)

**Solution**:
Since decoding currently falls back to main thread anyway, we can just disable the worker as described in the issue above, which will prevent the console errors from appearing

Resolves SUP-39292, SUP-39280

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
