### PR TITLE
fix(SUP-42730): Captions not showing after enabling

### DIFF
--- a/src/hls-adapter.ts
+++ b/src/hls-adapter.ts
@@ -126,7 +126,7 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
   private _nativeTextTracksMap: any = {};
   private _lastLoadedFragSN: number = -1;
   private _sameFragSNLoadedCount: number = 0;
-  private _isFirstSubtitleHide: boolean = true;
+  private _waitForSubtitleLoad: boolean = true;
   /**
    * an object containing all the events we bind and unbind to.
    * @member {Object} - _adapterEventsBindings
@@ -794,7 +794,7 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
 
   private _onSubtitleFragProcessed(): void {
     this._hls.subtitleTrack = -1;
-    this._isFirstSubtitleHide = false;
+    this._waitForSubtitleLoad = false;
     this._hls.off(Hlsjs.Events.SUBTITLE_FRAG_PROCESSED, this._onSubtitleFragProcessed, this._hls);
   }
 
@@ -809,7 +809,7 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
     }
     if (!this._hls.subtitleTracks.length) {
       this.disableNativeTextTracks();
-    } else if (this._isFirstSubtitleHide){
+    } else if (this._waitForSubtitleLoad){
       this._hls.on(Hlsjs.Events.SUBTITLE_FRAG_PROCESSED, this. _onSubtitleFragProcessed, this._hls)
     } else {
       this._hls.subtitleTrack = -1;

--- a/src/hls-adapter.ts
+++ b/src/hls-adapter.ts
@@ -126,6 +126,7 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
   private _nativeTextTracksMap: any = {};
   private _lastLoadedFragSN: number = -1;
   private _sameFragSNLoadedCount: number = 0;
+  private _firstHideTextTrack: boolean = true;
   /**
    * an object containing all the events we bind and unbind to.
    * @member {Object} - _adapterEventsBindings
@@ -791,6 +792,12 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
     this._onTrackChanged(textTrack);
   }
 
+  private _onSubtitleFragProcessed(): void {
+    this._hls.subtitleTrack = -1;
+    this._firstHideTextTrack = false;
+    this._hls.off(Hlsjs.Events.SUBTITLE_FRAG_PROCESSED, this._onSubtitleFragProcessed, this._hls);
+  }
+
   /** Hide the text track
    * @function hideTextTrack
    * @returns {void}
@@ -799,7 +806,11 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
   public hideTextTrack(): void {
     if (this._hls) {
       if (this._hls.subtitleTracks.length) {
-        this._hls.subtitleTrack = -1;
+        if (this._firstHideTextTrack){
+          this._hls.on(Hlsjs.Events.SUBTITLE_FRAG_PROCESSED, this. _onSubtitleFragProcessed, this._hls)
+        } else {
+          this._hls.subtitleTrack = -1;
+        }
       } else {
         this.disableNativeTextTracks();
       }


### PR DESCRIPTION
### Description of the Changes

**Issue:**
When play the video with caption disabled, caption is not shown after enable the caption (when the caption is default)

**Fix:**
Listen to SUBTITLE_FRAG_PROCESSED (hls event) that's triggered after the captions request and parsing then hide the captions from our side.

#### Resolves [SUP-42730](https://kaltura.atlassian.net/browse/SUP-42730)

[SUP-42730]: https://kaltura.atlassian.net/browse/SUP-42730?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ