### PR TITLE
fix(SUP-46270): [MultiCustomer] Captions Not Showing After Enabling Them

### DIFF
--- a/src/hls-adapter.ts
+++ b/src/hls-adapter.ts
@@ -809,7 +809,7 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
     }
     if (!this._hls.subtitleTracks.length) {
       this.disableNativeTextTracks();
-    } else if (this._waitForSubtitleLoad && this._hls.subtitleTracks.length > 1){
+    } else if (this._waitForSubtitleLoad && this._hls.subtitleTracks.some(track => track.default === true)){
       this._hls.on(Hlsjs.Events.SUBTITLE_FRAG_PROCESSED, this. _onSubtitleFragProcessed, this)
     } else {
       this._hls.subtitleTrack = -1;


### PR DESCRIPTION
### Description of the Changes

**Issue:**
When playing video with cc disabled, captions are not displayed after enable the caption. this happens when we have default caption and we generate webVTT captions.
This was fixed here - [#219](https://github.com/kaltura/playkit-js-hls/pull/219) but seems it was only partial fix and was tested only when "Auto generate WebVTT captions" is enabled. 
the fix here  - [#221](https://github.com/kaltura/playkit-js-hls/pull/221) should complete the fix but was tested only on original webVTT (and also not default caption) and not in generate webVTT.
This fix is tested and working for all cases - srt, webVTT and generate webVTT not and default captions

**Fix:**
Only if there is a default caption we will listen to SUBTITLE_FRAG_PROCESSED otherwise we can hide the caption immediately

#### Resolves [SUP-46270](https://kaltura.atlassian.net/browse/SUP-46270)


[SUP-42730]: https://kaltura.atlassian.net/browse/SUP-42730?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[SUP-46270]: https://kaltura.atlassian.net/browse/SUP-46270?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ