### PR TITLE
fix (SUP-45743): Errors on playback for mulitstream

### DIFF
--- a/src/hls-adapter.ts
+++ b/src/hls-adapter.ts
@@ -1154,7 +1154,7 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
           this._loadPromiseHandlers = null;
           this._loadPromise = undefined;
         }
-       this.destroy();
+      this.destroy();
       }
     } else {
       const {category, code}: ErrorDetailsType =

--- a/src/hls-adapter.ts
+++ b/src/hls-adapter.ts
@@ -1154,7 +1154,7 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
           this._loadPromiseHandlers = null;
           this._loadPromise = undefined;
         }
-      this.destroy();
+        this.destroy();
       }
     } else {
       const {category, code}: ErrorDetailsType =

--- a/src/hls-adapter.ts
+++ b/src/hls-adapter.ts
@@ -1184,7 +1184,7 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
       HlsAdapter._logger.error('recover aborted due to: MANIFEST_INCOMPATIBLE_CODECS_ERROR');
       recover = false;
     } else if (this._checkTimeDeltaHasPassed(now, this._recoverDecodingErrorDate, this._config.recoverDecodingErrorDelay)) {
-      if(reasonError && reasonError.includes('Found no media')) return recover;
+      if(mediaErrorName ===  Hlsjs.ErrorDetails.FRAG_PARSING_ERROR && reasonError && reasonError.includes('Found no media')) return recover;
       this._eventManager.listen(this._videoElement, EventType.LOADED_METADATA, this._onRecoveredCallback!);
       HlsAdapter._logger.debug('try to recover using: _recoverDecodingError()');
       this._recoverDecodingError();

--- a/src/hls-adapter.ts
+++ b/src/hls-adapter.ts
@@ -1137,7 +1137,7 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
         }
         break;
       case Hlsjs.ErrorTypes.MEDIA_ERROR:
-        if (this._handleMediaError(errorName)) {
+        if (this._handleMediaError(errorName, errorDataObject.reason)) {
           error = new PKError(PKError.Severity.RECOVERABLE, PKError.Category.MEDIA, PKError.Code.HLS_FATAL_MEDIA_ERROR, errorDataObject);
         } else {
           error = new PKError(PKError.Severity.CRITICAL, PKError.Category.MEDIA, PKError.Code.HLS_FATAL_MEDIA_ERROR, errorDataObject);
@@ -1154,7 +1154,7 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
           this._loadPromiseHandlers = null;
           this._loadPromise = undefined;
         }
-        this.destroy();
+       this.destroy();
       }
     } else {
       const {category, code}: ErrorDetailsType =
@@ -1176,7 +1176,7 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
    * @returns {boolean} - if media error is handled or not
    * @private
    */
-  private _handleMediaError(mediaErrorName: string): boolean {
+  private _handleMediaError(mediaErrorName: string, reasonError?: string): boolean {
     HlsAdapter._logger.error('_handleMediaError mediaErrorName:', mediaErrorName);
     const now: number = performance.now();
     let recover = true;
@@ -1184,6 +1184,7 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
       HlsAdapter._logger.error('recover aborted due to: MANIFEST_INCOMPATIBLE_CODECS_ERROR');
       recover = false;
     } else if (this._checkTimeDeltaHasPassed(now, this._recoverDecodingErrorDate, this._config.recoverDecodingErrorDelay)) {
+      if(reasonError && reasonError.includes('Found no media')) return recover;
       this._eventManager.listen(this._videoElement, EventType.LOADED_METADATA, this._onRecoveredCallback!);
       HlsAdapter._logger.debug('try to recover using: _recoverDecodingError()');
       this._recoverDecodingError();

--- a/src/hls-adapter.ts
+++ b/src/hls-adapter.ts
@@ -1184,7 +1184,7 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
       HlsAdapter._logger.error('recover aborted due to: MANIFEST_INCOMPATIBLE_CODECS_ERROR');
       recover = false;
     } else if (this._checkTimeDeltaHasPassed(now, this._recoverDecodingErrorDate, this._config.recoverDecodingErrorDelay)) {
-      if(mediaErrorName ===  Hlsjs.ErrorDetails.FRAG_PARSING_ERROR && reasonError && reasonError.includes('Found no media')) return recover;
+      if(mediaErrorName ===  Hlsjs.ErrorDetails.FRAG_PARSING_ERROR) return recover;
       this._eventManager.listen(this._videoElement, EventType.LOADED_METADATA, this._onRecoveredCallback!);
       HlsAdapter._logger.debug('try to recover using: _recoverDecodingError()');
       this._recoverDecodingError();

--- a/src/hls-adapter.ts
+++ b/src/hls-adapter.ts
@@ -1137,7 +1137,7 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
         }
         break;
       case Hlsjs.ErrorTypes.MEDIA_ERROR:
-        if (this._handleMediaError(errorName, errorDataObject.reason)) {
+        if (this._handleMediaError(errorName)) {
           error = new PKError(PKError.Severity.RECOVERABLE, PKError.Category.MEDIA, PKError.Code.HLS_FATAL_MEDIA_ERROR, errorDataObject);
         } else {
           error = new PKError(PKError.Severity.CRITICAL, PKError.Category.MEDIA, PKError.Code.HLS_FATAL_MEDIA_ERROR, errorDataObject);
@@ -1176,7 +1176,7 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
    * @returns {boolean} - if media error is handled or not
    * @private
    */
-  private _handleMediaError(mediaErrorName: string, reasonError?: string): boolean {
+  private _handleMediaError(mediaErrorName: string): boolean {
     HlsAdapter._logger.error('_handleMediaError mediaErrorName:', mediaErrorName);
     const now: number = performance.now();
     let recover = true;


### PR DESCRIPTION
**Issue:**
When get parsing error with No media found, the video stops and a black screen is appear.

**Fix:**
Mimic the behavior in V2 player, stop the video and not show a black screen.

[solved ] (https://kaltura.atlassian.net/browse/SUP-45743)