### PR TITLE
fix(SUP-47429): [HSBC] - Caption missing after the 05:00 minute

### DIFF
--- a/src/hls-adapter.ts
+++ b/src/hls-adapter.ts
@@ -793,7 +793,6 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
   }
 
   private _onSubtitleFragProcessed(): void {
-    this._hls.subtitleTrack = -1;
     this._waitForSubtitleLoad = false;
     this._hls.off(Hlsjs.Events.SUBTITLE_FRAG_PROCESSED, this._onSubtitleFragProcessed, this);
   }


### PR DESCRIPTION
issue:
when "Auto generate WebVTT caption" is enabled in partner, there is 1 default caption file longer then 5 minutes, and video start with captions disabled, after enable them and pass the 5 minute, captions are disappears.

solution:
remove this._hls.subtitleTrack = -1 on first load, as it cause that first captions file is loading, but it prevent from hls to load the second caption file.

solve [SUP-47429](https://kaltura.atlassian.net/browse/SUP-47429)


[SUP-47429]: https://kaltura.atlassian.net/browse/SUP-47429?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ