### PR TITLE
feat(FEC-14419): Expose Accessibility Audio \ Text Track Indications

### DIFF
--- a/src/hls-adapter.ts
+++ b/src/hls-adapter.ts
@@ -720,11 +720,11 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
         /transcribes-spoken-dialog/gi.test(characteristics) &&
         /describes-music-and-sound/gi.test(characteristics)
       ) {
-        return 'captions';
+        return TextTrack.KIND.CAPTIONS;
       }
     }
 
-    return 'subtitles';
+    return TextTrack.KIND.SUBTITLES;
   }
 
   /**

--- a/src/hls-adapter.ts
+++ b/src/hls-adapter.ts
@@ -634,7 +634,7 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
    * @private
    */
   private _parseTracks(): Array<Track> {
-    const audioTracks = this._parseAudioTracks(this._hls.audioTracks || []);
+    const audioTracks: Track[] = this._parseAudioTracks(this._hls.audioTracks || []);
     const videoTracks = this._parseVideoTracks(this._hls.levels || []);
     const textTracks = this._parseTextTracks(this._hls.subtitleTracks || []);
     return audioTracks.concat(videoTracks).concat(textTracks);
@@ -1025,7 +1025,7 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
     const videoTrack = this._playerTracks.find(track => {
       return track instanceof VideoTrack && track.index === data.level;
     })!;
-    this._onTrackChanged(videoTrack);
+    this._onTrackChanged(videoTrack as VideoTrack);
   }
 
   /**
@@ -1040,7 +1040,7 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
     const audioTrack = this._playerTracks.find(track => {
       return track instanceof AudioTrack && track.id === data.id;
     })!;
-    this._onTrackChanged(audioTrack);
+    this._onTrackChanged(audioTrack as AudioTrack);
     this._handleWaitingUponAudioTrackSwitch();
   }
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -52,7 +52,7 @@ module.exports = (env, {mode}) => {
       '@playkit-js/playkit-js': {
         commonjs: '@playkit-js/playkit-js',
         commonjs2: '@playkit-js/playkit-js',
-        amd: 'playkit-js',
+        amd: '@playkit-js/playkit-js',
         root: ['playkit', 'core']
       }
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1287,12 +1287,18 @@
   integrity sha512-BeiDM72c6GP8dZ6b2qScEpxT4sGECIJzjVGsanaTvXeFOkw3MoplAyz6HPKdrcLmidcinSl4yna5Yc9/ObwZow==
 
 "@playkit-js/playkit-js@canary":
-  version "0.84.2-canary.0-cceb0c7"
-  resolved "https://registry.yarnpkg.com/@playkit-js/playkit-js/-/playkit-js-0.84.2-canary.0-cceb0c7.tgz#a3b47545b2710acaf55811f48115bb75b8ff7972"
-  integrity sha512-pa2JDuNA1MD5cxYLT65GXVw8SLgL1QuTyklT88cxHa4Ir7XMbWJBV+1lp9RS363jNX1+pgMQT5lCWthEb8pqXg==
+  version "0.84.27-canary.0-ea430f6"
+  resolved "https://registry.yarnpkg.com/@playkit-js/playkit-js/-/playkit-js-0.84.27-canary.0-ea430f6.tgz#43b2454d4d36564c63833f233aafd3772a6e0e91"
+  integrity sha512-h5XVXlZ39osMcbpPsuRnwTojmfx6DvE+qHa0tIDfF4xibL4NJdWECXy7ygunCCAxUcMmCco4nkxA8J0NFhZC0g==
   dependencies:
+    "@playkit-js/webpack-common" "^1.0.3"
     js-logger "^1.6.0"
     ua-parser-js "^1.0.36"
+
+"@playkit-js/webpack-common@^1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@playkit-js/webpack-common/-/webpack-common-1.0.3.tgz#e7d47c6cd6ade579a160b08ccbe74889a567fcb6"
+  integrity sha512-qOkBsANu1ZloqWzan9lyU8jrrCVVH3KpCr1etXJI/UBTM84cGbvxIy8mHiXifenXjmGgKIGtnkNJt654Y1GMcg==
 
 "@rushstack/node-core-library@3.61.0":
   version "3.61.0"


### PR DESCRIPTION
### Description of the Changes

enhancement.

**Requirement:**
The requirement is to expose `kind` field for audio and text tracks according to accessibility parameters.
- audio tracks: possible values: `main`, `description` 
- text tracks: possible values: `subtitles`, `captions`

**Changes in this PR:**
for audio tracks:
- add `kind` field to `audioTracks` parsed in hls-adapter according to `hlsAudioTrack.characteristics` field

for text tracks:
- add a function to determine whether the text track is `captions` or `subtitles` according to `track.characteristics` (same implementation as in hlsjs)
- add `kind` field to `textTracks` in hls-adapter 

also fix the playkit-js dep in webpack file.

**depends on** [PR](https://github.com/kaltura/playkit-js/pull/815)

### Resolves FEC-14419
