### PR TITLE
fix(FEC-14472): part of the caption isn't shown on playback on VOD entry

### DIFF
--- a/src/hls-adapter.ts
+++ b/src/hls-adapter.ts
@@ -816,27 +816,14 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
     this._onTrackChanged(textTrack);
   }
 
-  private _onSubtitleFragProcessed(): void {
-    this._hls.subtitleTrack = -1;
-    this._waitForSubtitleLoad = false;
-    this._hls.off(Hlsjs.Events.SUBTITLE_FRAG_PROCESSED, this._onSubtitleFragProcessed, this);
-  }
-
   /** Hide the text track
    * @function hideTextTrack
    * @returns {void}
    * @public
    */
   public hideTextTrack(): void {
-    if (!this._hls){
-      return;
-    }
-    if (!this._hls.subtitleTracks.length) {
+    if (this._hls && !this._hls.subtitleTracks.length) {
       this.disableNativeTextTracks();
-    } else if (this._waitForSubtitleLoad && this._hls.subtitleTracks.some(track => track.default === true)){
-      this._hls.on(Hlsjs.Events.SUBTITLE_FRAG_PROCESSED, this. _onSubtitleFragProcessed, this)
-    } else {
-      this._hls.subtitleTrack = -1;
     }
   }
 
@@ -1279,7 +1266,6 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
     for (const [event, callback] of Object.entries<(...parms: any) => any>(this._adapterEventsBindings)) {
       this._hls.off(event as keyof HlsListeners, callback);
     }
-    this._hls.off(Hlsjs.Events.SUBTITLE_FRAG_PROCESSED, this._onSubtitleFragProcessed, this);
     this._videoElement.textTracks.onaddtrack = null;
     this._onRecoveredCallback = null;
     if (this._eventManager) {


### PR DESCRIPTION
### Description of the Changes

**the issue:**
part of the captions are not loaded when the following conditions are met:
- starting the playback with disabled captions
- captions are webvtt
- the captions are long (more than 5 minutes) and there are webvtt segments
- playing hls
- not native captions

**root cause:**
- first webvtt chunk is loaded
- since captions are started off - we are hiding the captions by setting `hls.subtitleTrack=-1`
- this is causing hls to disable the captions and stop the process of parsing the next chunk
- hls is not loading captions retroactively, hence, captions are "lost"

**solution:**
since the use-case is for when the text tracks are being rendered by kaltura player, we are controlling the visibility of the captions. we already handle resetting the view - we don't need to set `hls.subtitleTrack=-1` which is causing issues.

#### Resolves FEC-14472
