### PR TITLE
fix(SUP-47527): [Regents of Minnesota] Video Playback Issue in V7 Players

### DIFF
--- a/src/default-config.json
+++ b/src/default-config.json
@@ -7,7 +7,8 @@
   },
   "hlsConfig": {
     "fragLoadingMaxRetry": 4,
-    "maxMaxBufferLength": 60
+    "maxMaxBufferLength": 60,
+    "stretchShortVideoTrack": true
   },
   "network": {}
 }


### PR DESCRIPTION
### Description of the Changes

Add "stretchShortVideoTrack" configuration for cases where the audio is longer than the video so playback get stuck

#### Resolves [SUP-47527](https://kaltura.atlassian.net/browse/SUP-47527)


[SUP-47527]: https://kaltura.atlassian.net/browse/SUP-47527?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ