### PR TITLE
fix(SUP:49704): [Bloomberg] Latest V7 player does not play audio

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "chai": "^4.3.6",
     "copy-webpack-plugin": "^11.0.0",
     "eslint": "^8.54.0",
-    "hls.js": "1.6.0",
+    "hls.js": "1.5.8",
     "karma": "^6.4.0",
     "karma-chrome-launcher": "^3.1.1",
     "karma-firefox-launcher": "^1.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3742,10 +3742,10 @@ he@1.2.0:
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
 
-hls.js@1.6.0:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/hls.js/-/hls.js-1.6.0.tgz#ec0118f1dcd0fce536e52c27f674cdf944055b30"
-  integrity sha512-AlW8ymcDKZuKtzXCUmEy4nOcHRkebnShH6t6hC2+QJQP0WXlTUSSO9Kp22uSEYdCgpwkXEJsfOhqxrgO2tDctQ==
+hls.js@1.5.8:
+  version "1.5.8"
+  resolved "https://registry.yarnpkg.com/hls.js/-/hls.js-1.5.8.tgz#73c3d2984a56f103e6900bf7a5e65b288dba846e"
+  integrity sha512-hJYMPfLhWO7/7+n4f9pn6bOheCGx0WgvVz7k3ouq3Pp1bja48NN+HeCQu3XCGYzqWQF/wo7Sk6dJAyWVJD8ECA==
 
 hosted-git-info@^2.1.4:
   version "2.5.0"


### PR DESCRIPTION
### Description of the Changes

Audio only doesn't play with hls 1.6.0

Resolves [SUP-49704](https://kaltura.atlassian.net/browse/SUP-49704)
