### PR TITLE
fix(SUP-52119): embedded video stuck on loading at end of video in Firefox on macOS

### DIFF
--- a/src/hls-adapter.ts
+++ b/src/hls-adapter.ts
@@ -1181,6 +1181,12 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
         this.destroy();
       }
     } else {
+      if (errorType === Hlsjs.ErrorTypes.MEDIA_ERROR && errorName === Hlsjs.ErrorDetails.BUFFER_STALLED_ERROR && this._videoElement) {
+        const recovered = this._handleBufferStalledErrorAtEnd();
+        if (recovered) {
+          return;
+        }
+      }
       const {category, code}: ErrorDetailsType =
         this._requestFilterError || this._responseFilterError
           ? {
@@ -1226,6 +1232,25 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
       }
     }
     return recover;
+  }
+
+  /**
+   * if buffer stalled and video is close to end, end the video
+   * @returns {boolean} - if error is handled or not
+   * @private
+   */
+  private _handleBufferStalledErrorAtEnd() {
+    const currentTime = this._videoElement.currentTime;
+    const duration = this._videoElement.duration;
+    let recovered = false;
+    if (duration && duration - currentTime <= 0.2) {
+      // End the video
+      this._videoElement.currentTime = duration;
+      this._trigger(EventType.ENDED);
+      HlsAdapter._logger.info('Video ended due to buffer stall near end.');
+      recovered = true;
+    }
+    return recovered;
   }
 
   /**


### PR DESCRIPTION
issue:
sometimes video on firefox get bufferStallError and dont manage to end the video

root cause:
the video get few miliseconds to the end but dont manage to get to exact duration time.
this is not replicate on hlsjs demo

solution:
check if there is a stall error, and the video is few milliseconds away from the end, finish the video

solved [SUP-52119](https://kaltura.atlassian.net/browse/SUP-52119)


[SUP-52119]: https://kaltura.atlassian.net/browse/SUP-52119?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ