### PR TITLE
fix(SUP-52119): embedded video stuck on loading at end of video in Firefox on macOS

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "@babel/preset-typescript": "^7.22.15",
     "@microsoft/api-extractor": "^7.38.0",
     "@playkit-js/browserslist-config": "1.0.8",
-    "@playkit-js/playkit-js": "canary",
+    "@playkit-js/playkit-js": "0.84.44-canary.0-315659d",
     "@types/chai": "^4.3.3",
     "@types/mocha": "^9.1.1",
     "@types/sinon": "^10.0.20",

--- a/src/hls-adapter.ts
+++ b/src/hls-adapter.ts
@@ -1405,7 +1405,8 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
     } else {
       // consideration of the end of the playback in the target buffer calc
       targetBufferVal = this._videoElement.duration - this._videoElement.currentTime;
-      if (targetBufferVal <= 0.2) {
+      //for firefox on macOS if stream is near the end so end the stream
+      if (targetBufferVal <= 0.2 && Env.isMacOS && Env.isFirefox) {
         targetBufferVal = 0;
       }
     }

--- a/src/hls-adapter.ts
+++ b/src/hls-adapter.ts
@@ -102,7 +102,7 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
    * @type {{resolve: (result: Promise<R> | R) => void, reject: (error: any) => void}}
    * @private
    */
-  private _loadPromiseHandlers!: {resolve: (result: any) => void; reject: (error: any) => void} | null;
+  private _loadPromiseHandlers!: {resolve: (result: any) => void, reject: (error: any) => void} | null;
 
   /**
    * Reference to the player tracks.
@@ -724,10 +724,15 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
     return textTracks;
   }
 
-  private _captionsOrSubtitlesFromCharacteristics(track: MediaPlaylist): TextTrackKind {
+  private _captionsOrSubtitlesFromCharacteristics(
+    track: MediaPlaylist,
+  ): TextTrackKind {
     const characteristics = track.characteristics;
     if (characteristics) {
-      if (/transcribes-spoken-dialog/gi.test(characteristics) && /describes-music-and-sound/gi.test(characteristics)) {
+      if (
+        /transcribes-spoken-dialog/gi.test(characteristics) &&
+        /describes-music-and-sound/gi.test(characteristics)
+      ) {
         return TextTrack.KIND.CAPTIONS;
       }
     }
@@ -742,7 +747,7 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
    * @private
    */
   private _parseCEATextTrack(CEATextTrack: any): TextTrack | null {
-    let textTrack: TextTrack | null = null;
+    let textTrack:TextTrack | null = null;
     if (CEATextTrack.kind === 'captions') {
       const settings = {
         id: CEATextTrack.id,
@@ -1066,50 +1071,50 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
     const errorDataObject: any = {};
     errorDataObject.name = data.details;
     switch (errorDataObject.name) {
-      case Hlsjs.ErrorDetails.MANIFEST_LOAD_ERROR:
-      case Hlsjs.ErrorDetails.LEVEL_LOAD_ERROR:
-      case Hlsjs.ErrorDetails.AUDIO_TRACK_LOAD_ERROR:
-        errorDataObject.url = data.url;
-        errorDataObject.responseCode = data.response ? data.response.code : null;
-        break;
-      case Hlsjs.ErrorDetails.MANIFEST_LOAD_TIMEOUT:
-      case Hlsjs.ErrorDetails.LEVEL_LOAD_TIMEOUT:
-      case Hlsjs.ErrorDetails.AUDIO_TRACK_LOAD_TIMEOUT:
-        errorDataObject.url = data.url;
-        break;
-      case Hlsjs.ErrorDetails.MANIFEST_PARSING_ERROR:
-        errorDataObject.url = data.url;
-        errorDataObject.reason = data.reason;
-        break;
-      case Hlsjs.ErrorDetails.LEVEL_SWITCH_ERROR:
-        errorDataObject.level = data.level;
-        errorDataObject.reason = data.reason;
-        break;
-      case Hlsjs.ErrorDetails.FRAG_LOAD_ERROR:
-        errorDataObject.fragUrl = data.frag ? data.frag.url : null;
-        errorDataObject.responseCode = data.response ? data.response.code : null;
-        break;
-      case Hlsjs.ErrorDetails.FRAG_LOAD_TIMEOUT:
-        errorDataObject.fragUrl = data.frag ? data.frag.url : null;
-        break;
-      case Hlsjs.ErrorDetails.FRAG_DECRYPT_ERROR:
-      case Hlsjs.ErrorDetails.FRAG_PARSING_ERROR:
-        errorDataObject.reason = data.reason;
-        break;
-      case Hlsjs.ErrorDetails.KEY_LOAD_ERROR:
-        errorDataObject.fragDecryptedDataUri = data.frag && data.frag.decryptdata ? data.frag.decryptdata.uri : null;
-        errorDataObject.responseCode = data.response ? data.response.code : null;
-        break;
-      case Hlsjs.ErrorDetails.KEY_LOAD_TIMEOUT:
-        errorDataObject.fragDecryptedDataUri = data.frag && data.frag.decryptdata ? data.frag.decryptdata.uri : null;
-        break;
-      case Hlsjs.ErrorDetails.BUFFER_ADD_CODEC_ERROR:
-        errorDataObject.mimeType = data.mimeType;
-        errorDataObject.errorMsg = data.err ? data.err.message : null;
-        break;
-      case Hlsjs.ErrorDetails.BUFFER_STALLED_ERROR:
-        errorDataObject.buffer = data.buffer;
-        break;
+    case Hlsjs.ErrorDetails.MANIFEST_LOAD_ERROR:
+    case Hlsjs.ErrorDetails.LEVEL_LOAD_ERROR:
+    case Hlsjs.ErrorDetails.AUDIO_TRACK_LOAD_ERROR:
+      errorDataObject.url = data.url;
+      errorDataObject.responseCode = data.response ? data.response.code : null;
+      break;
+    case Hlsjs.ErrorDetails.MANIFEST_LOAD_TIMEOUT:
+    case Hlsjs.ErrorDetails.LEVEL_LOAD_TIMEOUT:
+    case Hlsjs.ErrorDetails.AUDIO_TRACK_LOAD_TIMEOUT:
+      errorDataObject.url = data.url;
+      break;
+    case Hlsjs.ErrorDetails.MANIFEST_PARSING_ERROR:
+      errorDataObject.url = data.url;
+      errorDataObject.reason = data.reason;
+      break;
+    case Hlsjs.ErrorDetails.LEVEL_SWITCH_ERROR:
+      errorDataObject.level = data.level;
+      errorDataObject.reason = data.reason;
+      break;
+    case Hlsjs.ErrorDetails.FRAG_LOAD_ERROR:
+      errorDataObject.fragUrl = data.frag ? data.frag.url : null;
+      errorDataObject.responseCode = data.response ? data.response.code : null;
+      break;
+    case Hlsjs.ErrorDetails.FRAG_LOAD_TIMEOUT:
+      errorDataObject.fragUrl = data.frag ? data.frag.url : null;
+      break;
+    case Hlsjs.ErrorDetails.FRAG_DECRYPT_ERROR:
+    case Hlsjs.ErrorDetails.FRAG_PARSING_ERROR:
+      errorDataObject.reason = data.reason;
+      break;
+    case Hlsjs.ErrorDetails.KEY_LOAD_ERROR:
+      errorDataObject.fragDecryptedDataUri = data.frag && data.frag.decryptdata ? data.frag.decryptdata.uri : null;
+      errorDataObject.responseCode = data.response ? data.response.code : null;
+      break;
+    case Hlsjs.ErrorDetails.KEY_LOAD_TIMEOUT:
+      errorDataObject.fragDecryptedDataUri = data.frag && data.frag.decryptdata ? data.frag.decryptdata.uri : null;
+      break;
+    case Hlsjs.ErrorDetails.BUFFER_ADD_CODEC_ERROR:
+      errorDataObject.mimeType = data.mimeType;
+      errorDataObject.errorMsg = data.err ? data.err.message : null;
+      break;
+    case Hlsjs.ErrorDetails.BUFFER_STALLED_ERROR:
+      errorDataObject.buffer = data.buffer;
+      break;
     }
     if (this._requestFilterError || this._responseFilterError) {
       errorDataObject.reason = data.response.text;
@@ -1131,40 +1136,40 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
     if (errorFatal) {
       let error: PKError;
       switch (errorType) {
-        case Hlsjs.ErrorTypes.NETWORK_ERROR:
-          {
-            let code;
-            if (this._requestFilterError) {
-              code = PKError.Code.REQUEST_FILTER_ERROR;
-            } else if (this._responseFilterError) {
-              code = PKError.Code.RESPONSE_FILTER_ERROR;
-            } else {
-              code = PKError.Code.HTTP_ERROR;
-            }
-            if (
-              [Hlsjs.ErrorDetails.MANIFEST_LOAD_ERROR, Hlsjs.ErrorDetails.MANIFEST_LOAD_TIMEOUT].includes(errorName) &&
-              !this._triedReloadWithRedirect &&
-              !this._config.forceRedirectExternalStreams &&
-              !this._requestFilterError &&
-              !this._responseFilterError
-            ) {
-              error = new PKError(PKError.Severity.RECOVERABLE, PKError.Category.NETWORK, code, errorDataObject);
-              this._reloadWithDirectManifest();
-            } else {
-              error = new PKError(PKError.Severity.CRITICAL, PKError.Category.NETWORK, code, errorDataObject);
-            }
-          }
-          break;
-        case Hlsjs.ErrorTypes.MEDIA_ERROR:
-          if (this._handleMediaError(errorName)) {
-            error = new PKError(PKError.Severity.RECOVERABLE, PKError.Category.MEDIA, PKError.Code.HLS_FATAL_MEDIA_ERROR, errorDataObject);
+      case Hlsjs.ErrorTypes.NETWORK_ERROR:
+        {
+          let code;
+          if (this._requestFilterError) {
+            code = PKError.Code.REQUEST_FILTER_ERROR;
+          } else if (this._responseFilterError) {
+            code = PKError.Code.RESPONSE_FILTER_ERROR;
           } else {
-            error = new PKError(PKError.Severity.CRITICAL, PKError.Category.MEDIA, PKError.Code.HLS_FATAL_MEDIA_ERROR, errorDataObject);
+            code = PKError.Code.HTTP_ERROR;
           }
-          break;
-        default:
-          error = new PKError(PKError.Severity.CRITICAL, PKError.Category.PLAYER, PKError.Code.HLS_FATAL_MEDIA_ERROR, errorDataObject);
-          break;
+          if (
+            [Hlsjs.ErrorDetails.MANIFEST_LOAD_ERROR, Hlsjs.ErrorDetails.MANIFEST_LOAD_TIMEOUT].includes(errorName) &&
+            !this._triedReloadWithRedirect &&
+            !this._config.forceRedirectExternalStreams &&
+            !this._requestFilterError &&
+            !this._responseFilterError
+          ) {
+            error = new PKError(PKError.Severity.RECOVERABLE, PKError.Category.NETWORK, code, errorDataObject);
+            this._reloadWithDirectManifest();
+          } else {
+            error = new PKError(PKError.Severity.CRITICAL, PKError.Category.NETWORK, code, errorDataObject);
+          }
+        }
+        break;
+      case Hlsjs.ErrorTypes.MEDIA_ERROR:
+        if (this._handleMediaError(errorName)) {
+          error = new PKError(PKError.Severity.RECOVERABLE, PKError.Category.MEDIA, PKError.Code.HLS_FATAL_MEDIA_ERROR, errorDataObject);
+        } else {
+          error = new PKError(PKError.Severity.CRITICAL, PKError.Category.MEDIA, PKError.Code.HLS_FATAL_MEDIA_ERROR, errorDataObject);
+        }
+        break;
+      default:
+        error = new PKError(PKError.Severity.CRITICAL, PKError.Category.PLAYER, PKError.Code.HLS_FATAL_MEDIA_ERROR, errorDataObject);
+        break;
       }
       this._trigger(EventType.ERROR, error);
       if (error && error.severity === PKError.Severity.CRITICAL) {
@@ -1185,9 +1190,9 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
       const {category, code}: ErrorDetailsType =
         this._requestFilterError || this._responseFilterError
           ? {
-              category: PKError.Category.NETWORK,
-              code: this._requestFilterError ? PKError.Code.REQUEST_FILTER_ERROR : PKError.Code.RESPONSE_FILTER_ERROR
-            }
+            category: PKError.Category.NETWORK,
+            code: this._requestFilterError ? PKError.Code.REQUEST_FILTER_ERROR : PKError.Code.RESPONSE_FILTER_ERROR
+          }
           : HlsJsErrorMap[errorName] || {category: 0, code: 0};
       HlsAdapter._logger.warn(new PKError(PKError.Severity.RECOVERABLE, category, code, errorDataObject));
     }
@@ -1209,7 +1214,7 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
       HlsAdapter._logger.error('recover aborted due to: MANIFEST_INCOMPATIBLE_CODECS_ERROR');
       recover = false;
     } else if (this._checkTimeDeltaHasPassed(now, this._recoverDecodingErrorDate, this._config.recoverDecodingErrorDelay)) {
-      if (mediaErrorName === Hlsjs.ErrorDetails.FRAG_PARSING_ERROR) {
+      if (mediaErrorName ===  Hlsjs.ErrorDetails.FRAG_PARSING_ERROR) {
         HlsAdapter._logger.error('Manifest parsing error on ' + this._videoElement.currentTime + '. Try to recover');
         return recover;
       }

--- a/src/hls-adapter.ts
+++ b/src/hls-adapter.ts
@@ -1407,6 +1407,7 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
       targetBufferVal = this._videoElement.duration - this._videoElement.currentTime;
 
       //for firefox on macOS if stream is near the end so end the stream
+      //@ts-expect-error todo:remove this comment when type is updated
       if (targetBufferVal <= 0.2 && Env.isMacOS && Env.isFirefox) {
         targetBufferVal = 0;
       }

--- a/src/hls-adapter.ts
+++ b/src/hls-adapter.ts
@@ -1405,6 +1405,7 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
     } else {
       // consideration of the end of the playback in the target buffer calc
       targetBufferVal = this._videoElement.duration - this._videoElement.currentTime;
+
       //for firefox on macOS if stream is near the end so end the stream
       if (targetBufferVal <= 0.2 && Env.isMacOS && Env.isFirefox) {
         targetBufferVal = 0;

--- a/src/hls-adapter.ts
+++ b/src/hls-adapter.ts
@@ -102,7 +102,7 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
    * @type {{resolve: (result: Promise<R> | R) => void, reject: (error: any) => void}}
    * @private
    */
-  private _loadPromiseHandlers!: {resolve: (result: any) => void, reject: (error: any) => void} | null;
+  private _loadPromiseHandlers!: {resolve: (result: any) => void; reject: (error: any) => void} | null;
 
   /**
    * Reference to the player tracks.
@@ -724,15 +724,10 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
     return textTracks;
   }
 
-  private _captionsOrSubtitlesFromCharacteristics(
-    track: MediaPlaylist,
-  ): TextTrackKind {
+  private _captionsOrSubtitlesFromCharacteristics(track: MediaPlaylist): TextTrackKind {
     const characteristics = track.characteristics;
     if (characteristics) {
-      if (
-        /transcribes-spoken-dialog/gi.test(characteristics) &&
-        /describes-music-and-sound/gi.test(characteristics)
-      ) {
+      if (/transcribes-spoken-dialog/gi.test(characteristics) && /describes-music-and-sound/gi.test(characteristics)) {
         return TextTrack.KIND.CAPTIONS;
       }
     }
@@ -747,7 +742,7 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
    * @private
    */
   private _parseCEATextTrack(CEATextTrack: any): TextTrack | null {
-    let textTrack:TextTrack | null = null;
+    let textTrack: TextTrack | null = null;
     if (CEATextTrack.kind === 'captions') {
       const settings = {
         id: CEATextTrack.id,
@@ -1071,50 +1066,50 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
     const errorDataObject: any = {};
     errorDataObject.name = data.details;
     switch (errorDataObject.name) {
-    case Hlsjs.ErrorDetails.MANIFEST_LOAD_ERROR:
-    case Hlsjs.ErrorDetails.LEVEL_LOAD_ERROR:
-    case Hlsjs.ErrorDetails.AUDIO_TRACK_LOAD_ERROR:
-      errorDataObject.url = data.url;
-      errorDataObject.responseCode = data.response ? data.response.code : null;
-      break;
-    case Hlsjs.ErrorDetails.MANIFEST_LOAD_TIMEOUT:
-    case Hlsjs.ErrorDetails.LEVEL_LOAD_TIMEOUT:
-    case Hlsjs.ErrorDetails.AUDIO_TRACK_LOAD_TIMEOUT:
-      errorDataObject.url = data.url;
-      break;
-    case Hlsjs.ErrorDetails.MANIFEST_PARSING_ERROR:
-      errorDataObject.url = data.url;
-      errorDataObject.reason = data.reason;
-      break;
-    case Hlsjs.ErrorDetails.LEVEL_SWITCH_ERROR:
-      errorDataObject.level = data.level;
-      errorDataObject.reason = data.reason;
-      break;
-    case Hlsjs.ErrorDetails.FRAG_LOAD_ERROR:
-      errorDataObject.fragUrl = data.frag ? data.frag.url : null;
-      errorDataObject.responseCode = data.response ? data.response.code : null;
-      break;
-    case Hlsjs.ErrorDetails.FRAG_LOAD_TIMEOUT:
-      errorDataObject.fragUrl = data.frag ? data.frag.url : null;
-      break;
-    case Hlsjs.ErrorDetails.FRAG_DECRYPT_ERROR:
-    case Hlsjs.ErrorDetails.FRAG_PARSING_ERROR:
-      errorDataObject.reason = data.reason;
-      break;
-    case Hlsjs.ErrorDetails.KEY_LOAD_ERROR:
-      errorDataObject.fragDecryptedDataUri = data.frag && data.frag.decryptdata ? data.frag.decryptdata.uri : null;
-      errorDataObject.responseCode = data.response ? data.response.code : null;
-      break;
-    case Hlsjs.ErrorDetails.KEY_LOAD_TIMEOUT:
-      errorDataObject.fragDecryptedDataUri = data.frag && data.frag.decryptdata ? data.frag.decryptdata.uri : null;
-      break;
-    case Hlsjs.ErrorDetails.BUFFER_ADD_CODEC_ERROR:
-      errorDataObject.mimeType = data.mimeType;
-      errorDataObject.errorMsg = data.err ? data.err.message : null;
-      break;
-    case Hlsjs.ErrorDetails.BUFFER_STALLED_ERROR:
-      errorDataObject.buffer = data.buffer;
-      break;
+      case Hlsjs.ErrorDetails.MANIFEST_LOAD_ERROR:
+      case Hlsjs.ErrorDetails.LEVEL_LOAD_ERROR:
+      case Hlsjs.ErrorDetails.AUDIO_TRACK_LOAD_ERROR:
+        errorDataObject.url = data.url;
+        errorDataObject.responseCode = data.response ? data.response.code : null;
+        break;
+      case Hlsjs.ErrorDetails.MANIFEST_LOAD_TIMEOUT:
+      case Hlsjs.ErrorDetails.LEVEL_LOAD_TIMEOUT:
+      case Hlsjs.ErrorDetails.AUDIO_TRACK_LOAD_TIMEOUT:
+        errorDataObject.url = data.url;
+        break;
+      case Hlsjs.ErrorDetails.MANIFEST_PARSING_ERROR:
+        errorDataObject.url = data.url;
+        errorDataObject.reason = data.reason;
+        break;
+      case Hlsjs.ErrorDetails.LEVEL_SWITCH_ERROR:
+        errorDataObject.level = data.level;
+        errorDataObject.reason = data.reason;
+        break;
+      case Hlsjs.ErrorDetails.FRAG_LOAD_ERROR:
+        errorDataObject.fragUrl = data.frag ? data.frag.url : null;
+        errorDataObject.responseCode = data.response ? data.response.code : null;
+        break;
+      case Hlsjs.ErrorDetails.FRAG_LOAD_TIMEOUT:
+        errorDataObject.fragUrl = data.frag ? data.frag.url : null;
+        break;
+      case Hlsjs.ErrorDetails.FRAG_DECRYPT_ERROR:
+      case Hlsjs.ErrorDetails.FRAG_PARSING_ERROR:
+        errorDataObject.reason = data.reason;
+        break;
+      case Hlsjs.ErrorDetails.KEY_LOAD_ERROR:
+        errorDataObject.fragDecryptedDataUri = data.frag && data.frag.decryptdata ? data.frag.decryptdata.uri : null;
+        errorDataObject.responseCode = data.response ? data.response.code : null;
+        break;
+      case Hlsjs.ErrorDetails.KEY_LOAD_TIMEOUT:
+        errorDataObject.fragDecryptedDataUri = data.frag && data.frag.decryptdata ? data.frag.decryptdata.uri : null;
+        break;
+      case Hlsjs.ErrorDetails.BUFFER_ADD_CODEC_ERROR:
+        errorDataObject.mimeType = data.mimeType;
+        errorDataObject.errorMsg = data.err ? data.err.message : null;
+        break;
+      case Hlsjs.ErrorDetails.BUFFER_STALLED_ERROR:
+        errorDataObject.buffer = data.buffer;
+        break;
     }
     if (this._requestFilterError || this._responseFilterError) {
       errorDataObject.reason = data.response.text;
@@ -1136,40 +1131,40 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
     if (errorFatal) {
       let error: PKError;
       switch (errorType) {
-      case Hlsjs.ErrorTypes.NETWORK_ERROR:
-        {
-          let code;
-          if (this._requestFilterError) {
-            code = PKError.Code.REQUEST_FILTER_ERROR;
-          } else if (this._responseFilterError) {
-            code = PKError.Code.RESPONSE_FILTER_ERROR;
-          } else {
-            code = PKError.Code.HTTP_ERROR;
+        case Hlsjs.ErrorTypes.NETWORK_ERROR:
+          {
+            let code;
+            if (this._requestFilterError) {
+              code = PKError.Code.REQUEST_FILTER_ERROR;
+            } else if (this._responseFilterError) {
+              code = PKError.Code.RESPONSE_FILTER_ERROR;
+            } else {
+              code = PKError.Code.HTTP_ERROR;
+            }
+            if (
+              [Hlsjs.ErrorDetails.MANIFEST_LOAD_ERROR, Hlsjs.ErrorDetails.MANIFEST_LOAD_TIMEOUT].includes(errorName) &&
+              !this._triedReloadWithRedirect &&
+              !this._config.forceRedirectExternalStreams &&
+              !this._requestFilterError &&
+              !this._responseFilterError
+            ) {
+              error = new PKError(PKError.Severity.RECOVERABLE, PKError.Category.NETWORK, code, errorDataObject);
+              this._reloadWithDirectManifest();
+            } else {
+              error = new PKError(PKError.Severity.CRITICAL, PKError.Category.NETWORK, code, errorDataObject);
+            }
           }
-          if (
-            [Hlsjs.ErrorDetails.MANIFEST_LOAD_ERROR, Hlsjs.ErrorDetails.MANIFEST_LOAD_TIMEOUT].includes(errorName) &&
-            !this._triedReloadWithRedirect &&
-            !this._config.forceRedirectExternalStreams &&
-            !this._requestFilterError &&
-            !this._responseFilterError
-          ) {
-            error = new PKError(PKError.Severity.RECOVERABLE, PKError.Category.NETWORK, code, errorDataObject);
-            this._reloadWithDirectManifest();
+          break;
+        case Hlsjs.ErrorTypes.MEDIA_ERROR:
+          if (this._handleMediaError(errorName)) {
+            error = new PKError(PKError.Severity.RECOVERABLE, PKError.Category.MEDIA, PKError.Code.HLS_FATAL_MEDIA_ERROR, errorDataObject);
           } else {
-            error = new PKError(PKError.Severity.CRITICAL, PKError.Category.NETWORK, code, errorDataObject);
+            error = new PKError(PKError.Severity.CRITICAL, PKError.Category.MEDIA, PKError.Code.HLS_FATAL_MEDIA_ERROR, errorDataObject);
           }
-        }
-        break;
-      case Hlsjs.ErrorTypes.MEDIA_ERROR:
-        if (this._handleMediaError(errorName)) {
-          error = new PKError(PKError.Severity.RECOVERABLE, PKError.Category.MEDIA, PKError.Code.HLS_FATAL_MEDIA_ERROR, errorDataObject);
-        } else {
-          error = new PKError(PKError.Severity.CRITICAL, PKError.Category.MEDIA, PKError.Code.HLS_FATAL_MEDIA_ERROR, errorDataObject);
-        }
-        break;
-      default:
-        error = new PKError(PKError.Severity.CRITICAL, PKError.Category.PLAYER, PKError.Code.HLS_FATAL_MEDIA_ERROR, errorDataObject);
-        break;
+          break;
+        default:
+          error = new PKError(PKError.Severity.CRITICAL, PKError.Category.PLAYER, PKError.Code.HLS_FATAL_MEDIA_ERROR, errorDataObject);
+          break;
       }
       this._trigger(EventType.ERROR, error);
       if (error && error.severity === PKError.Severity.CRITICAL) {
@@ -1190,9 +1185,9 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
       const {category, code}: ErrorDetailsType =
         this._requestFilterError || this._responseFilterError
           ? {
-            category: PKError.Category.NETWORK,
-            code: this._requestFilterError ? PKError.Code.REQUEST_FILTER_ERROR : PKError.Code.RESPONSE_FILTER_ERROR
-          }
+              category: PKError.Category.NETWORK,
+              code: this._requestFilterError ? PKError.Code.REQUEST_FILTER_ERROR : PKError.Code.RESPONSE_FILTER_ERROR
+            }
           : HlsJsErrorMap[errorName] || {category: 0, code: 0};
       HlsAdapter._logger.warn(new PKError(PKError.Severity.RECOVERABLE, category, code, errorDataObject));
     }
@@ -1214,7 +1209,7 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
       HlsAdapter._logger.error('recover aborted due to: MANIFEST_INCOMPATIBLE_CODECS_ERROR');
       recover = false;
     } else if (this._checkTimeDeltaHasPassed(now, this._recoverDecodingErrorDate, this._config.recoverDecodingErrorDelay)) {
-      if (mediaErrorName ===  Hlsjs.ErrorDetails.FRAG_PARSING_ERROR) {
+      if (mediaErrorName === Hlsjs.ErrorDetails.FRAG_PARSING_ERROR) {
         HlsAdapter._logger.error('Manifest parsing error on ' + this._videoElement.currentTime + '. Try to recover');
         return recover;
       }
@@ -1239,7 +1234,7 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
    * @returns {boolean} - if error is handled or not
    * @private
    */
-  private _handleBufferStalledErrorAtEnd() {
+  private _handleBufferStalledErrorAtEnd(): boolean {
     const currentTime = this._videoElement.currentTime;
     const duration = this._videoElement.duration;
     let recovered = false;

--- a/src/hls-adapter.ts
+++ b/src/hls-adapter.ts
@@ -1405,6 +1405,9 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
     } else {
       // consideration of the end of the playback in the target buffer calc
       targetBufferVal = this._videoElement.duration - this._videoElement.currentTime;
+      if (targetBufferVal <= 0.2) {
+        targetBufferVal = 0;
+      }
     }
     targetBufferVal = Math.min(targetBufferVal, this._hls.config.maxMaxBufferLength + this._getLevelDetails().targetduration);
     return targetBufferVal;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1286,10 +1286,10 @@
   resolved "https://registry.yarnpkg.com/@playkit-js/browserslist-config/-/browserslist-config-1.0.8.tgz#735256ba560063d397d4b8776acb865e8697a287"
   integrity sha512-BeiDM72c6GP8dZ6b2qScEpxT4sGECIJzjVGsanaTvXeFOkw3MoplAyz6HPKdrcLmidcinSl4yna5Yc9/ObwZow==
 
-"@playkit-js/playkit-js@canary":
-  version "0.84.27-canary.0-ea430f6"
-  resolved "https://registry.yarnpkg.com/@playkit-js/playkit-js/-/playkit-js-0.84.27-canary.0-ea430f6.tgz#43b2454d4d36564c63833f233aafd3772a6e0e91"
-  integrity sha512-h5XVXlZ39osMcbpPsuRnwTojmfx6DvE+qHa0tIDfF4xibL4NJdWECXy7ygunCCAxUcMmCco4nkxA8J0NFhZC0g==
+"@playkit-js/playkit-js@0.84.44-canary.0-315659d":
+  version "0.84.44-canary.0-315659d"
+  resolved "https://registry.yarnpkg.com/@playkit-js/playkit-js/-/playkit-js-0.84.44-canary.0-315659d.tgz#452339c0eb46c48a0e1a66be22caeb17e09a2095"
+  integrity sha512-KIFh6P7Et1ZvSGLiR0xAkXetB2fPutaybpT3VyMKB2Gf9KJkNUWTS6lIdQrMuiTH67wE7dVn8tFLgdI3M7FbrA==
   dependencies:
     "@playkit-js/webpack-common" "^1.0.3"
     js-logger "^1.6.0"


### PR DESCRIPTION
issue:
sometimes video on firefox stuck on spinner without any error

root cause:
the video get few miliseconds to the end but dont manage to get to exact duration time.
this is not replicate on hlsjs demo

solution:
check on targetBuffer if video is few milliseconds away from the end, then put targetBuffer as 0 to mark end of stream

solved [SUP-52119](https://kaltura.atlassian.net/browse/SUP-52119)


[SUP-52119]: https://kaltura.atlassian.net/browse/SUP-52119?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

related: https://github.com/kaltura/playkit-js/pull/876