### PR TITLE
fix(hls-adapter): translate HLS audio track labels to native names (SUP-52289)

### DIFF
--- a/src/hls-adapter.ts
+++ b/src/hls-adapter.ts
@@ -10,6 +10,7 @@ import {
   Error as PKError,
   EventType,
   filterTracksByRestriction,
+  getNativeLanguageName,
   IMediaSourceAdapter,
   PKABRRestrictionObject,
   PKMediaSourceObject,
@@ -663,12 +664,18 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
   private _parseAudioTracks(hlsAudioTracks: Array<MediaPlaylist>): AudioTrack[] {
     const audioTracks: AudioTrack[] = [];
     for (let i = 0; i < hlsAudioTracks.length; i++) {
-      // Create audio tracks
+      // Use the ISO language code to derive the native display name (e.g. "es" → "español").
+      // This ensures parity with the DASH adapter, which receives ISO codes from Shaka and
+      // displays them as native names. The HLS manifest NAME= attribute is typically an English
+      // word (e.g. "Spanish"), so we use it only as a fallback when the language code is absent.
+      const lang = hlsAudioTracks[i].lang;
+      const manifestName = hlsAudioTracks[i].name;
+      const label = getNativeLanguageName(lang, manifestName);
       const settings = {
         id: hlsAudioTracks[i].id,
         active: this._hls.audioTrack === hlsAudioTracks[i].id,
-        label: hlsAudioTracks[i].name,
-        language: hlsAudioTracks[i].lang,
+        label,
+        language: lang,
         index: i,
         kind: hlsAudioTracks[i].characteristics ? AudioTrackKind.DESCRIPTION : AudioTrackKind.MAIN,
         flavorId: this._extractFlavorId(hlsAudioTracks[i].url)


### PR DESCRIPTION
## Problem

On iOS Safari (and desktop when hls.js is active), HLS audio track labels show English words ("Spanish", "Portuguese", "Japanese") instead of native language names ("Español", "Português", "日本語"). The DASH adapter shows native names because Shaka returns ISO codes and the DASH manifest uses native names; the HLS adapter uses the English NAME= attribute from the manifest verbatim.

## Root Cause

_parseAudioTracks used hlsAudioTracks[i].name directly as the label. The HLS manifest NAME= attribute is English (e.g. NAME="Spanish"), while the LANGUAGE= attribute carries the ISO code (e.g. LANGUAGE="es"). The ISO code was set as language but the English name was shown to the user.

## Fix

Import the new getNativeLanguageName() exported by @playkit-js/playkit-js and use it in _parseAudioTracks() to derive the label from the ISO language code (hlsAudioTracks[i].lang) via Intl.DisplayNames, falling back to the manifest NAME= value when the language code is absent or the API is unavailable.

This ensures parity with the DASH adapter: both now show native language names.

## Files Changed

- src/hls-adapter.ts — import getNativeLanguageName, use in _parseAudioTracks

## Companion PR

kaltura/playkit-js#878 — adds the getNativeLanguageName utility and fixes the native adapter

## Jira

https://kaltura.atlassian.net/browse/SUP-52289