### PR TITLE
fix(audio-tracks): use Intl.DisplayNames for native language labels (SUP-52289)

### DIFF
--- a/api-extractor/playkit-js-hls.api.json
+++ b/api-extractor/playkit-js-hls.api.json
@@ -238,10 +238,6 @@
                   "text": "protected static _logger: "
                 },
                 {
-                  "kind": "Content",
-                  "text": "import('js-logger')."
-                },
-                {
                   "kind": "Reference",
                   "text": "ILogger",
                   "canonicalReference": "js-logger!ILogger:interface"
@@ -257,7 +253,7 @@
               "name": "_logger",
               "propertyTypeTokenRange": {
                 "startIndex": 1,
-                "endIndex": 3
+                "endIndex": 2
               },
               "isStatic": true,
               "isProtected": true,

--- a/src/hls-adapter.ts
+++ b/src/hls-adapter.ts
@@ -10,6 +10,7 @@ import {
   Error as PKError,
   EventType,
   filterTracksByRestriction,
+  getNativeLanguageName,
   IMediaSourceAdapter,
   PKABRRestrictionObject,
   PKMediaSourceObject,
@@ -667,7 +668,7 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
       const settings = {
         id: hlsAudioTracks[i].id,
         active: this._hls.audioTrack === hlsAudioTracks[i].id,
-        label: hlsAudioTracks[i].name,
+        label: getNativeLanguageName(hlsAudioTracks[i].lang, hlsAudioTracks[i].name),
         language: hlsAudioTracks[i].lang,
         index: i,
         kind: hlsAudioTracks[i].characteristics ? AudioTrackKind.DESCRIPTION : AudioTrackKind.MAIN,


### PR DESCRIPTION
## Problem

On iOS Safari, when the player falls back from DASH to HLS, audio track labels are sourced from the HLS manifest NAME= attribute (English words: "Spanish", "Japanese") rather than the native script name. The DASH code path produces ISO code-based labels that the player translates consistently. This mismatch causes different label text depending on stream type.

## Root Cause

hls-adapter.ts _parseAudioTracks sets label: hlsAudioTracks[i].name directly from the HLS manifest NAME= field. There is no conversion to native language name.

## Fix

Import getNativeLanguageName from @playkit-js/playkit-js (added in companion PR kaltura/playkit-js#879) and apply it at the label assignment in _parseAudioTracks:

  label: getNativeLanguageName(hlsAudioTracks[i].lang, hlsAudioTracks[i].name),

The lang field (ISO 639 code from the LANGUAGE= attribute) is used as the primary input. The manifest NAME= value is the safe fallback when the lang is absent.

## Files Changed

- src/hls-adapter.ts — import getNativeLanguageName, apply at label assignment

## Tests

- Full suite: 27 tests completed, 0 failures (34 skipped — integration tests requiring network)

## Depends On

kaltura/playkit-js#879 must be merged and published before this PR can be released.

## Jira

https://kaltura.atlassian.net/browse/SUP-52289