### PR TITLE
fix(hls-adapter): preserve manifest NAME for audio track label dedup (SUP-52840)

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "@babel/preset-typescript": "^7.22.15",
     "@microsoft/api-extractor": "^7.38.0",
     "@playkit-js/browserslist-config": "1.0.8",
-    "@playkit-js/playkit-js": "canary",
+    "@playkit-js/playkit-js": "0.84.45-canary.0-8cf2a7b",
     "@types/chai": "^4.3.3",
     "@types/mocha": "^9.1.1",
     "@types/sinon": "^10.0.20",

--- a/src/hls-adapter.ts
+++ b/src/hls-adapter.ts
@@ -664,7 +664,6 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
   private _parseAudioTracks(hlsAudioTracks: Array<MediaPlaylist>): AudioTrack[] {
     const audioTracks: AudioTrack[] = [];
     for (let i = 0; i < hlsAudioTracks.length; i++) {
-      // Create audio tracks
       const settings = {
         id: hlsAudioTracks[i].id,
         active: this._hls.audioTrack === hlsAudioTracks[i].id,
@@ -672,7 +671,10 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
         language: hlsAudioTracks[i].lang,
         index: i,
         kind: hlsAudioTracks[i].characteristics ? AudioTrackKind.DESCRIPTION : AudioTrackKind.MAIN,
-        flavorId: this._extractFlavorId(hlsAudioTracks[i].url)
+        flavorId: this._extractFlavorId(hlsAudioTracks[i].url),
+        // Raw manifest NAME — used downstream to deduplicate labels when two tracks share the
+        // same ISO language code (e.g. English + English Audio Description, both lang="en").
+        manifestName: hlsAudioTracks[i].name || ''
       };
       audioTracks.push(new AudioTrack(settings));
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1286,10 +1286,10 @@
   resolved "https://registry.yarnpkg.com/@playkit-js/browserslist-config/-/browserslist-config-1.0.8.tgz#735256ba560063d397d4b8776acb865e8697a287"
   integrity sha512-BeiDM72c6GP8dZ6b2qScEpxT4sGECIJzjVGsanaTvXeFOkw3MoplAyz6HPKdrcLmidcinSl4yna5Yc9/ObwZow==
 
-"@playkit-js/playkit-js@canary":
-  version "0.84.27-canary.0-ea430f6"
-  resolved "https://registry.yarnpkg.com/@playkit-js/playkit-js/-/playkit-js-0.84.27-canary.0-ea430f6.tgz#43b2454d4d36564c63833f233aafd3772a6e0e91"
-  integrity sha512-h5XVXlZ39osMcbpPsuRnwTojmfx6DvE+qHa0tIDfF4xibL4NJdWECXy7ygunCCAxUcMmCco4nkxA8J0NFhZC0g==
+"@playkit-js/playkit-js@0.84.45-canary.0-8cf2a7b":
+  version "0.84.45-canary.0-8cf2a7b"
+  resolved "https://registry.yarnpkg.com/@playkit-js/playkit-js/-/playkit-js-0.84.45-canary.0-8cf2a7b.tgz#833c0b501ed65dd634f489aa87b24abfee944e2b"
+  integrity sha512-5Yn0xORG3ndg6SrgwHAdkbgTGD+xe4isN4/0wwn6+XRjY5dqVV950OrdxjXep6lGvNttskYUWWV2ZH7B78+PCw==
   dependencies:
     "@playkit-js/webpack-common" "^1.0.3"
     js-logger "^1.6.0"


### PR DESCRIPTION
## Summary
- Passes the raw HLS manifest `NAME` attribute as `manifestName` on each `AudioTrack` so that `audioDescriptionTrackHandler` downstream can deduplicate labels when two tracks share the same ISO language code
- Fixes the case where the AD manifest track **lacks a `CHARACTERISTICS` attribute** — the only previous deduplication path — causing both tracks to resolve to the same Intl-translated label (`"English"`) and both items showing a checkmark simultaneously

## Root cause
Manifests like the one in SUP-52840 have:
```
#EXT-X-MEDIA:TYPE=AUDIO,LANGUAGE="en",NAME="English"
#EXT-X-MEDIA:TYPE=AUDIO,LANGUAGE="en",NAME="Eng - Audio Description"  ← no CHARACTERISTICS
```
`getNativeLanguageName("en", ...)` always returns `"English"` via `Intl.DisplayNames`, discarding the manifest `NAME`. Without `CHARACTERISTICS`, `kind` stays `MAIN` and `audioDescriptionTrackHandler` never fires. Result: two identical `"English"` labels, dual checkmarks.

## Fix
Store `hlsAudioTracks[i].name` as `manifestName` on the `AudioTrack` settings object. The dedup pass in `audioDescriptionTrackHandler` (playkit-js) uses this to replace duplicate labels with the distinct manifest name.

## Related PRs
- playkit-js: `fix/sup-52840-audio-desc-label-dedup` — dedup pass + guard
- playkit-js-ui: `fix/sup-52840-audio-menu-active-by-id` — checkmark fix

## Test plan
- [ ] Entry `1_fwpyikph` (partner 5479302): audio menu shows `"English"` and `"Eng - Audio Description"` as distinct labels
- [ ] Only the active track has a checkmark
- [ ] No regression for entries with a single audio track
- [ ] No regression for entries where `CHARACTERISTICS` is present

🤖 Generated with [Claude Code](https://claude.com/claude-code)