### PR TITLE
feat(FEC-15007): Live streaming: report primary vs secondary stream dimension to Kava on live playback events

### DIFF
--- a/src/hls-adapter.ts
+++ b/src/hls-adapter.ts
@@ -133,6 +133,7 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
   private _lastLoadedFragSN: number = -1;
   private _sameFragSNLoadedCount: number = 0;
   private _waitForSubtitleLoad: boolean = true;
+  private _liveEntryStValue: string  = '';
   /**
    * an object containing all the events we bind and unbind to.
    * @member {Object} - _adapterEventsBindings
@@ -656,6 +657,30 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
   }
 
   /**
+   * Extract st value from URL path (/st/{value}/...).
+   * @param {string} url - The URL to parse.
+   * @returns {?string} - The extracted st value or null if not found.
+   * @private
+   */
+  private _extractStValue(url?: string): string {
+    if (!url) {
+      return '';
+    }
+    const match = url.match(/(?:^|\/)st\/([^/?#]+)/);
+    return match ? decodeURIComponent(match[1]) : '';
+  }
+
+  /**
+   * Update extracted st value from manifest level URL.
+   * @returns {void}
+   * @private
+   */
+  private _updateLiveEntryStValue(): void {
+    const levelUrl = this._hls.levels?.[0]?.url?.[0] || '';
+    this._liveEntryStValue = this._extractStValue(levelUrl);
+  }
+
+  /**
    * Parse hls audio tracks into player audio tracks.
    * @param {Array<Object>} hlsAudioTracks - The hls audio tracks.
    * @returns {Array<AudioTrack>} - The parsed audio tracks.
@@ -967,6 +992,15 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
   }
 
   /**
+   * Returns extracted st value only for live entries.
+   * @returns {string} - st value for live entry, otherwise empty string.
+   * @public
+   */
+  public getLiveEntryStValue(): string {
+    return this._liveEntryStValue;
+  }
+
+  /**
    * Fired after manifest has been loaded.
    * @function _onManifestLoaded
    * @param {any} data - the data of the manifest load event
@@ -978,6 +1012,7 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
     if (!this._hls.config.autoStartLoad) {
       this._hls.startLoad(this._startTime);
     }
+    this._updateLiveEntryStValue();
     this._playerTracks = this._parseTracks();
     // set current level to disable the auto selection in hls
     if (!this._config.abr.enabled) {

--- a/src/hls-adapter.ts
+++ b/src/hls-adapter.ts
@@ -660,7 +660,7 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
   /**
    * Extract st value from URL path (/st/{value}/...).
    * @param {string} url - The URL to parse.
-   * @returns {?string} - The extracted st value or null if not found.
+   * @returns {string} - The extracted st value or empty string if not found.
    * @private
    */
   private _extractStValue(url: string): string {

--- a/src/hls-adapter.ts
+++ b/src/hls-adapter.ts
@@ -133,7 +133,7 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
   private _lastLoadedFragSN: number = -1;
   private _sameFragSNLoadedCount: number = 0;
   private _waitForSubtitleLoad: boolean = true;
-  private _liveEntryStValue: string  = '';
+  private _liveEntryStValue: string = '';
   /**
    * an object containing all the events we bind and unbind to.
    * @member {Object} - _adapterEventsBindings
@@ -663,10 +663,7 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
    * @returns {?string} - The extracted st value or null if not found.
    * @private
    */
-  private _extractStValue(url?: string): string {
-    if (!url) {
-      return '';
-    }
+  private _extractStValue(url: string): string {
     const match = url.match(/(?:^|\/)st\/([^/?#]+)/);
     return match ? decodeURIComponent(match[1]) : '';
   }

--- a/src/hls-adapter.ts
+++ b/src/hls-adapter.ts
@@ -664,8 +664,7 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
    * @private
    */
   private _extractStValue(url: string): string {
-    const match = url.match(/(?:^|\/)st\/([^/?#]+)/);
-    return match ? decodeURIComponent(match[1]) : '';
+    return url.match(/\/st\/([01])\//)?.[1] ?? '';
   }
 
   /**

--- a/src/hls-adapter.ts
+++ b/src/hls-adapter.ts
@@ -626,6 +626,7 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
     this._removeBindings();
     this._requestFilterError = false;
     this._responseFilterError = false;
+    this._liveEntryStValue = '';
     this._hls.detachMedia();
     this._hls.destroy();
   }
@@ -671,13 +672,13 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
   }
 
   /**
-   * Update extracted st value from manifest level URL.
+   * Update extracted st value from a media URL.
+   * @param {string} levelM3u8Url - The loaded media playlist URL.
    * @returns {void}
    * @private
    */
-  private _updateLiveEntryStValue(): void {
-    const levelUrl = this._hls.levels?.[0]?.url?.[0] || '';
-    this._liveEntryStValue = this._extractStValue(levelUrl);
+  private _updateLiveEntryStValue(levelM3u8Url: string): void {
+    this._liveEntryStValue = this._extractStValue(levelM3u8Url);
   }
 
   /**
@@ -1012,7 +1013,6 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
     if (!this._hls.config.autoStartLoad) {
       this._hls.startLoad(this._startTime);
     }
-    this._updateLiveEntryStValue();
     this._playerTracks = this._parseTracks();
     // set current level to disable the auto selection in hls
     if (!this._config.abr.enabled) {
@@ -1390,6 +1390,10 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
    */
   private _onLevelLoaded = (e: any, data: any): Promise<void> | undefined => {
     if (this.isLive()) {
+      if (!this._liveEntryStValue) {
+        const levelM3u8Url = data?.details?.url || data?.url || '';
+        this._updateLiveEntryStValue(levelM3u8Url);
+      }
       const {
         details: {endSN}
       } = data;


### PR DESCRIPTION
### Description of the Changes

Adding getLiveEntryStValue function to extract live stream type from the manifest response.

related pr: https://github.com/kaltura/kaltura-player-js/pull/1247, https://github.com/kaltura/playkit-js-kava/pull/224, https://github.com/kaltura/playkit-js/pull/889, https://github.com/kaltura/playkit-js-dash/pull/274

#### Resolves [FEC-15007](https://kaltura.atlassian.net/browse/FEC-15007)





[FEC-15007]: https://kaltura.atlassian.net/browse/FEC-15007?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ