### PR TITLE
fix(FEC-15069): Live seamless failover| streamType reports incorrect stream

### DIFF
--- a/src/hls-adapter.ts
+++ b/src/hls-adapter.ts
@@ -1390,7 +1390,7 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
   private _onLevelLoaded = (e: any, data: any): Promise<void> | undefined => {
     if (this.isLive()) {
       const levelM3u8Url = data?.details?.url || data?.url || '';
-      this._updateLiveEntryStValue(levelM3u8Url);      
+      this._updateLiveEntryStValue(levelM3u8Url);
       const {
         details: {endSN}
       } = data;

--- a/src/hls-adapter.ts
+++ b/src/hls-adapter.ts
@@ -674,7 +674,10 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
    * @private
    */
   private _updateLiveEntryStValue(levelM3u8Url: string): void {
-    this._liveEntryStValue = this._extractStValue(levelM3u8Url);
+    const newStValue = this._extractStValue(levelM3u8Url);
+    if (newStValue !== this._liveEntryStValue) {
+      this._liveEntryStValue = newStValue;
+    }
   }
 
   /**
@@ -1386,10 +1389,9 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
    */
   private _onLevelLoaded = (e: any, data: any): Promise<void> | undefined => {
     if (this.isLive()) {
-      if (!this._liveEntryStValue) {
-        const levelM3u8Url = data?.details?.url || data?.url || '';
-        this._updateLiveEntryStValue(levelM3u8Url);
-      }
+      const levelM3u8Url = data?.details?.url || data?.url || '';
+      this._updateLiveEntryStValue(levelM3u8Url);
+      
       const {
         details: {endSN}
       } = data;

--- a/src/hls-adapter.ts
+++ b/src/hls-adapter.ts
@@ -1390,8 +1390,7 @@ export default class HlsAdapter extends BaseMediaSourceAdapter {
   private _onLevelLoaded = (e: any, data: any): Promise<void> | undefined => {
     if (this.isLive()) {
       const levelM3u8Url = data?.details?.url || data?.url || '';
-      this._updateLiveEntryStValue(levelM3u8Url);
-      
+      this._updateLiveEntryStValue(levelM3u8Url);      
       const {
         details: {endSN}
       } = data;


### PR DESCRIPTION
### Description of the Changes

**Issue:**
In seamless live segments can be from primary and backup even if primary are streaming well. this happens because hls playing best resolution regardless stream type. 
**Fix:**
In each level loaded check if stream type is changed and if yes update the live stream var (instead of doing it only for the first level).

#### Resolves [FEC-15069](https://kaltura.atlassian.net/browse/FEC-15069)


[FEC-15069]: https://kaltura.atlassian.net/browse/FEC-15069?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ